### PR TITLE
Various java 8 cleanups.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,9 @@
 		<developerConnection>https://github.com/igniterealtime/tinder.git</developerConnection>
 		<url>https://github.com/igniterealtime/tinder</url>
 	</scm>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 	<build>
 		<plugins>
 			<plugin>
@@ -116,10 +119,6 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
-						<configuration>
-							<!-- TODO: Clean up the Javadoc so the build no longer fails if doclint is enabled -->
-							<doclint>none</doclint>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/src/main/java/org/jivesoftware/util/FastDateFormat.java
+++ b/src/main/java/org/jivesoftware/util/FastDateFormat.java
@@ -102,6 +102,7 @@ public class FastDateFormat {
 
     /**
      * @param pattern {@link java.text.SimpleDateFormat} compatible pattern
+     * @return date format with specified pattern.
      */
     public static FastDateFormat getInstance(String pattern) throws IllegalArgumentException {
         return getInstance(pattern, null, null, null);
@@ -111,6 +112,7 @@ public class FastDateFormat {
      * @param pattern  {@link java.text.SimpleDateFormat} compatible pattern
      * @param timeZone optional time zone, overrides time zone of formatted
      *                 date
+     * @return date format with specified pattern and timezone.
      */
     public static FastDateFormat getInstance(String pattern, TimeZone timeZone) throws IllegalArgumentException {
         return getInstance(pattern, timeZone, null, null);
@@ -119,6 +121,7 @@ public class FastDateFormat {
     /**
      * @param pattern {@link java.text.SimpleDateFormat} compatible pattern
      * @param locale  optional locale, overrides system locale
+     * @return date format with specified pattern and locale.
      */
     public static FastDateFormat getInstance(String pattern, Locale locale) throws IllegalArgumentException {
         return getInstance(pattern, null, locale, null);
@@ -128,6 +131,7 @@ public class FastDateFormat {
      * @param pattern {@link java.text.SimpleDateFormat} compatible pattern
      * @param symbols optional date format symbols, overrides symbols for
      *                system locale
+     * @return date format with specified pattern and format symbols.
      */
     public static FastDateFormat getInstance(String pattern, DateFormatSymbols symbols) throws IllegalArgumentException {
         return getInstance(pattern, null, null, symbols);
@@ -138,6 +142,7 @@ public class FastDateFormat {
      * @param timeZone optional time zone, overrides time zone of formatted
      *                 date
      * @param locale   optional locale, overrides system locale
+     * @return date format with specified pattern, timezone and locale.
      */
     public static FastDateFormat getInstance(String pattern, TimeZone timeZone, Locale locale) throws IllegalArgumentException {
         return getInstance(pattern, timeZone, locale, null);
@@ -150,6 +155,7 @@ public class FastDateFormat {
      * @param locale   optional locale, overrides system locale
      * @param symbols  optional date format symbols, overrides symbols for
      *                 provided locale
+     * @return date format with specified pattern, timezone, locale and format symbols.
      */
     public static synchronized FastDateFormat getInstance(String pattern, TimeZone timeZone, Locale locale,
                                                           DateFormatSymbols symbols) throws IllegalArgumentException {
@@ -184,6 +190,7 @@ public class FastDateFormat {
      * @param timeZone optional time zone, overrides time zone of formatted
      *                 date
      * @param locale   optional locale, overrides system locale
+     * @return date format with specified style, timezone and locale.
      */
     public static synchronized FastDateFormat getDateInstance(Object style, TimeZone timeZone, Locale locale)
         throws IllegalArgumentException {
@@ -229,6 +236,7 @@ public class FastDateFormat {
      * @param timeZone optional time zone, overrides time zone of formatted
      *                 date
      * @param locale   optional locale, overrides system locale
+     * @return date format with specified style, timezone and locale.
      */
     public static synchronized FastDateFormat getTimeInstance(Object style, TimeZone timeZone, Locale locale)
         throws IllegalArgumentException {
@@ -275,6 +283,7 @@ public class FastDateFormat {
      * @param timeZone  optional time zone, overrides time zone of formatted
      *                  date
      * @param locale    optional locale, overrides system locale
+     * @return date format with specified date, time styles, timezone and locale.
      */
     public static synchronized FastDateFormat getDateTimeInstance(Object dateStyle, Object timeStyle, TimeZone timeZone, Locale locale)
         throws IllegalArgumentException {
@@ -660,11 +669,17 @@ public class FastDateFormat {
     /**
      * Returns the time zone used by this formatter, or null if time zone of
      * formatted dates is used instead.
+     * @return time zone.
      */
     public TimeZone getTimeZone() {
         return mTimeZone;
     }
 
+    /**
+     * Return the locale used by this formatter, or null if locale of
+     * formatted dates is used instead.
+     * @return locale.
+     */
     public Locale getLocale() {
         return mLocale;
     }
@@ -673,6 +688,7 @@ public class FastDateFormat {
      * Returns an estimate for the maximum length date that this date
      * formatter will produce. The actual formatted length will almost always
      * be less than or equal to this amount.
+     * @return maximum length date estimate.
      */
     public int getMaxLengthEstimate() {
         return mMaxLengthEstimate;

--- a/src/main/java/org/jivesoftware/util/FastDateFormat.java
+++ b/src/main/java/org/jivesoftware/util/FastDateFormat.java
@@ -103,8 +103,7 @@ public class FastDateFormat {
     /**
      * @param pattern {@link java.text.SimpleDateFormat} compatible pattern
      */
-    public static FastDateFormat getInstance(String pattern)
-        throws IllegalArgumentException {
+    public static FastDateFormat getInstance(String pattern) throws IllegalArgumentException {
         return getInstance(pattern, null, null, null);
     }
 
@@ -113,8 +112,7 @@ public class FastDateFormat {
      * @param timeZone optional time zone, overrides time zone of formatted
      *                 date
      */
-    public static FastDateFormat getInstance
-    (String pattern, TimeZone timeZone) throws IllegalArgumentException {
+    public static FastDateFormat getInstance(String pattern, TimeZone timeZone) throws IllegalArgumentException {
         return getInstance(pattern, timeZone, null, null);
     }
 
@@ -122,8 +120,7 @@ public class FastDateFormat {
      * @param pattern {@link java.text.SimpleDateFormat} compatible pattern
      * @param locale  optional locale, overrides system locale
      */
-    public static FastDateFormat getInstance
-    (String pattern, Locale locale) throws IllegalArgumentException {
+    public static FastDateFormat getInstance(String pattern, Locale locale) throws IllegalArgumentException {
         return getInstance(pattern, null, locale, null);
     }
 
@@ -132,9 +129,7 @@ public class FastDateFormat {
      * @param symbols optional date format symbols, overrides symbols for
      *                system locale
      */
-    public static FastDateFormat getInstance
-    (String pattern, DateFormatSymbols symbols)
-        throws IllegalArgumentException {
+    public static FastDateFormat getInstance(String pattern, DateFormatSymbols symbols) throws IllegalArgumentException {
         return getInstance(pattern, null, null, symbols);
     }
 
@@ -144,9 +139,7 @@ public class FastDateFormat {
      *                 date
      * @param locale   optional locale, overrides system locale
      */
-    public static FastDateFormat getInstance
-    (String pattern, TimeZone timeZone, Locale locale)
-        throws IllegalArgumentException {
+    public static FastDateFormat getInstance(String pattern, TimeZone timeZone, Locale locale) throws IllegalArgumentException {
         return getInstance(pattern, timeZone, locale, null);
     }
 
@@ -158,10 +151,8 @@ public class FastDateFormat {
      * @param symbols  optional date format symbols, overrides symbols for
      *                 provided locale
      */
-    public static synchronized FastDateFormat getInstance
-    (String pattern, TimeZone timeZone, Locale locale,
-     DateFormatSymbols symbols)
-        throws IllegalArgumentException {
+    public static synchronized FastDateFormat getInstance(String pattern, TimeZone timeZone, Locale locale,
+                                                          DateFormatSymbols symbols) throws IllegalArgumentException {
         Object key = pattern;
 
         if (timeZone != null) {
@@ -194,8 +185,7 @@ public class FastDateFormat {
      *                 date
      * @param locale   optional locale, overrides system locale
      */
-    public static synchronized FastDateFormat getDateInstance
-    (Object style, TimeZone timeZone, Locale locale)
+    public static synchronized FastDateFormat getDateInstance(Object style, TimeZone timeZone, Locale locale)
         throws IllegalArgumentException {
         Object key = style;
 
@@ -211,7 +201,7 @@ public class FastDateFormat {
         if (format == null) {
             int ds;
             try {
-                ds = ((Integer) style).intValue();
+                ds = (Integer) style;
             } catch (ClassCastException e) {
                 throw new IllegalArgumentException
                     ("Illegal date style: " + style);
@@ -240,8 +230,7 @@ public class FastDateFormat {
      *                 date
      * @param locale   optional locale, overrides system locale
      */
-    public static synchronized FastDateFormat getTimeInstance
-    (Object style, TimeZone timeZone, Locale locale)
+    public static synchronized FastDateFormat getTimeInstance(Object style, TimeZone timeZone, Locale locale)
         throws IllegalArgumentException {
         Object key = style;
 
@@ -257,7 +246,7 @@ public class FastDateFormat {
         if (format == null) {
             int ts;
             try {
-                ts = ((Integer) style).intValue();
+                ts = (Integer) style;
             } catch (ClassCastException e) {
                 throw new IllegalArgumentException
                     ("Illegal time style: " + style);
@@ -287,8 +276,7 @@ public class FastDateFormat {
      *                  date
      * @param locale    optional locale, overrides system locale
      */
-    public static synchronized FastDateFormat getDateTimeInstance
-    (Object dateStyle, Object timeStyle, TimeZone timeZone, Locale locale)
+    public static synchronized FastDateFormat getDateTimeInstance(Object dateStyle, Object timeStyle, TimeZone timeZone, Locale locale)
         throws IllegalArgumentException {
         Object key = new Pair(dateStyle, timeStyle);
 
@@ -305,7 +293,7 @@ public class FastDateFormat {
         if (format == null) {
             int ds;
             try {
-                ds = ((Integer) dateStyle).intValue();
+                ds = (Integer) dateStyle;
             } catch (ClassCastException e) {
                 throw new IllegalArgumentException
                     ("Illegal date style: " + dateStyle);
@@ -313,7 +301,7 @@ public class FastDateFormat {
 
             int ts;
             try {
-                ts = ((Integer) timeStyle).intValue();
+                ts = (Integer) timeStyle;
             } catch (ClassCastException e) {
                 throw new IllegalArgumentException
                     ("Illegal time style: " + timeStyle);
@@ -336,10 +324,7 @@ public class FastDateFormat {
         return format;
     }
 
-    static synchronized String getTimeZoneDisplay(TimeZone tz,
-                                                  boolean daylight,
-                                                  int style,
-                                                  Locale locale) {
+    static synchronized String getTimeZoneDisplay(TimeZone tz, boolean daylight, int style, Locale locale) {
         Object key = new TimeZoneDisplayKey(tz, daylight, style, locale);
         String value = (String) cTimeZoneDisplayCache.get(key);
         if (value == null) {
@@ -360,8 +345,7 @@ public class FastDateFormat {
     /**
      * Returns a list of Rules.
      */
-    private static List parse(String pattern, TimeZone timeZone, Locale locale,
-                              DateFormatSymbols symbols) {
+    private static List parse(String pattern, TimeZone timeZone, Locale locale, DateFormatSymbols symbols) {
         List rules = new ArrayList();
 
         String[] ERAs = symbols.getEras();
@@ -483,7 +467,7 @@ public class FastDateFormat {
     }
 
     private static String parseToken(String pattern, int[] indexRef) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
 
         int i = indexRef[0];
         int length = pattern.length();
@@ -567,8 +551,7 @@ public class FastDateFormat {
      * @param timeZone optional time zone, overrides time zone of formatted
      *                 date
      */
-    private FastDateFormat(String pattern, TimeZone timeZone)
-        throws IllegalArgumentException {
+    private FastDateFormat(String pattern, TimeZone timeZone) throws IllegalArgumentException {
         this(pattern, timeZone, null, null);
     }
 
@@ -576,8 +559,7 @@ public class FastDateFormat {
      * @param pattern {@link java.text.SimpleDateFormat} compatible pattern
      * @param locale  optional locale, overrides system locale
      */
-    private FastDateFormat(String pattern, Locale locale)
-        throws IllegalArgumentException {
+    private FastDateFormat(String pattern, Locale locale) throws IllegalArgumentException {
         this(pattern, null, locale, null);
     }
 
@@ -586,8 +568,7 @@ public class FastDateFormat {
      * @param symbols optional date format symbols, overrides symbols for
      *                system locale
      */
-    private FastDateFormat(String pattern, DateFormatSymbols symbols)
-        throws IllegalArgumentException {
+    private FastDateFormat(String pattern, DateFormatSymbols symbols) throws IllegalArgumentException {
         this(pattern, null, null, symbols);
     }
 
@@ -597,8 +578,7 @@ public class FastDateFormat {
      *                 date
      * @param locale   optional locale, overrides system locale
      */
-    private FastDateFormat(String pattern, TimeZone timeZone, Locale locale)
-        throws IllegalArgumentException {
+    private FastDateFormat(String pattern, TimeZone timeZone, Locale locale) throws IllegalArgumentException {
         this(pattern, timeZone, locale, null);
     }
 
@@ -610,8 +590,7 @@ public class FastDateFormat {
      * @param symbols  optional date format symbols, overrides symbols for
      *                 provided locale
      */
-    private FastDateFormat(String pattern, TimeZone timeZone, Locale locale,
-                           DateFormatSymbols symbols)
+    private FastDateFormat(String pattern, TimeZone timeZone, Locale locale, DateFormatSymbols symbols)
         throws IllegalArgumentException {
         if (locale == null) {
             locale = Locale.getDefault();
@@ -668,10 +647,8 @@ public class FastDateFormat {
     }
 
     private StringBuffer applyRules(Calendar calendar, StringBuffer buf) {
-        Rule[] rules = mRules;
-        int len = mRules.length;
-        for (int i = 0; i < len; i++) {
-            rules[i].appendTo(buf, calendar);
+        for (Rule mRule : mRules) {
+            mRule.appendTo(buf, calendar);
         }
         return buf;
     }
@@ -855,7 +832,7 @@ public class FastDateFormat {
                 for (int i = mSize; --i >= digits; ) {
                     buffer.append('0');
                 }
-                buffer.append(Integer.toString(value));
+                buffer.append(value);
             }
         }
     }
@@ -880,7 +857,7 @@ public class FastDateFormat {
                 buffer.append((char) (value / 10 + '0'));
                 buffer.append((char) (value % 10 + '0'));
             } else {
-                buffer.append(Integer.toString(value));
+                buffer.append(value);
             }
         }
     }

--- a/src/main/java/org/xmpp/component/AbstractComponent.java
+++ b/src/main/java/org/xmpp/component/AbstractComponent.java
@@ -39,7 +39,7 @@ import org.xmpp.util.XMPPConstants;
 /**
  * This class provides a default {@link Component} implementation. Most of the
  * default functionality can be overridden by overriding specific methods.
- * <p/>
+ * <br>
  * These XMPP features are implemented in the abstract component:
  * <ul>
  * <li>Service Discovery (XEP-0030)</li>
@@ -47,7 +47,6 @@ import org.xmpp.util.XMPPConstants;
  * <li>Last Activity (XEP-0012)</li>
  * <li>Entity Time(XEP-0202)</li>
  * </ul>
- * <p/>
  * This implementation uses the producer/consumer pattern, in which it takes the
  * role of a consumer of stanzas. Every abstract component has a dedicated
  * thread pool to process stanzas. This pool will use up to the configured
@@ -57,21 +56,21 @@ import org.xmpp.util.XMPPConstants;
  * queue is full, the stanza will be dropped and an exception will be logged. If
  * the stanza was an IQ request stanza, an IQ error stanza
  * (internal-server-error/wait) will be returned.
- * <p/>
+ * <br>
  * By default, instances of this class are guaranteed to return an IQ response
  * on every consumed IQ of the <tt>get</tt> or <tt>set</tt> type, as required by
  * the XMPP specification. If the abstract component cannot formulate a valid
  * response and the extending implementation does not provide a response either
  * (by returning <tt>null</tt> on invocations of {@link #handleIQGet(IQ)} and
  * {@link #handleIQSet(IQ)}) an IQ error response is returned.
- * <p />
+ * <br>
  * The behavior described above can be disabled by setting a corresponding flag
  * in one of the constructors. If an instance is configured in such a way,
  * <tt>null</tt> responses provided by the extending implementation are not
  * translated in an IQ error. This allows the extending implementation to
  * respond to IQ requests in an asynchrous manner. It will be up to the
  * extending implementation to ensure that every IQ request is responded to.
- * <p/>
+ * <br>
  * Note that instances of this class can be used to implement internal (e.g.
  * Openfire plugins) as well as external components.
  *
@@ -246,7 +245,7 @@ public abstract class AbstractComponent implements Component {
     /**
      * This method applies default processing to received IQ stanzas. This
      * method:
-     * <p/>
+     * <br>
      * <ul>
      * <li>calls methods to process IQ requests (type <tt>get</tt> and
      * <tt>set</tt>). If no response to these request are returned, this method
@@ -260,7 +259,7 @@ public abstract class AbstractComponent implements Component {
      * if the processing of an IQ request (type <tt>get</tt> or <tt>set</tt>)
      * resulted in an Exception being thrown.</li>
      * </ul>
-     * <p/>
+     * <br>
      * Note that if you want to add or adjust functionality, you should
      * <strong>not</strong> override this method. Instead, you probably want to
      * override any of these methods: {@link #handleIQGet()},
@@ -416,7 +415,7 @@ public abstract class AbstractComponent implements Component {
     /**
      * Processes IQ request stanzas (IQ stanzas of type <tt>get</tt> or
      * <tt>set</tt>. This method will, in order:
-     * <p/>
+     * <br>
      * <ol>
      * <li>check if the stanza is a valid request stanza. If not, an IQ stanza
      * of type <tt>error</tt>, condition 'bad-request' is returned;</li>
@@ -427,17 +426,17 @@ public abstract class AbstractComponent implements Component {
      * {@link #handleIQSet()} if the above actions did not apply to the request.
      * </li>
      * </ol>
-     * <p/>
+     * <br>
      * Note that if this method returns <tt>null</tt>, an IQ stanza of type
      * <tt>error</tt>, condition <tt>feature-not-implemented</tt> will be
      * returned to the sender of the original request. This behavior can be
      * disabled by setting the <tt>enforceIQResult</tt> argument in the
      * constructor to <tt>false</tt>.
-     * <p/>
+     * <br>
      * Note that if this method throws an Exception, an IQ stanza of type
      * <tt>error</tt>, condition 'internal-server-error' will be returned to the
      * sender of the original request.
-     * <p/>
+     * <br>
      * Note that if you want to add or adjust functionality, you should
      * <strong>not</strong> override this method. Instead, you probably want to
      * override any of these methods: {@link #handleIQGet()},
@@ -543,17 +542,17 @@ public abstract class AbstractComponent implements Component {
     /**
      * Override this method to handle the IQ stanzas of type <tt>get</tt> that
      * could not be processed by the {@link AbstractComponent} implementation.
-     * <p/>
+     * <br>
      * Note that, as any IQ stanza of type <tt>get</tt> must be replied to,
      * returning <tt>null</tt> from this method equals returning an IQ error
      * stanza of type 'feature-not-implemented' (this behavior can be disabled
      * by setting the <tt>enforceIQResult</tt> argument in the constructor to
      * <tt>false</tt>).
-     * <p/>
+     * <br>
      * Note that if this method throws an Exception, an IQ stanza of type
      * <tt>error</tt>, condition 'internal-server-error' will be returned to the
      * sender of the original request.
-     * <p/>
+     * <br>
      * The default implementation of this method returns <tt>null</tt>. It is
      * expected that most child classes will override this method.
      *
@@ -562,6 +561,8 @@ public abstract class AbstractComponent implements Component {
      *            by this component.
      * @return the response the to request stanza, or <tt>null</tt> to indicate
      *         'feature-not-available'.
+     * @throws Exception
+     *          if internal error occurs.
      */
     protected IQ handleIQGet(IQ iq) throws Exception {
         // Doesn't do anything. Override this method to process IQ get
@@ -572,17 +573,17 @@ public abstract class AbstractComponent implements Component {
     /**
      * Override this method to handle the IQ stanzas of type <tt>set</tt> that
      * could not be processed by the {@link AbstractComponent} implementation.
-     * <p/>
+     * <br>
      * Note that, as any IQ stanza of type <tt>set</tt> must be replied to,
      * returning <tt>null</tt> from this method equals returning an IQ error
      * stanza of type 'feature-not-implemented' {this behavior can be disabled
      * by setting the <tt>enforceIQResult</tt> argument in the constructor to
      * <tt>false</tt>).
-     * <p/>
+     * <br>
      * Note that if this method throws an Exception, an IQ stanza of type
      * <tt>error</tt>, condition 'internal-server-error' will be returned to the
      * sender of the original request.
-     * <p/>
+     * <br>
      * The default implementation of this method returns <tt>null</tt>. It is
      * expected that most child classes will override this method.
      *
@@ -591,6 +592,8 @@ public abstract class AbstractComponent implements Component {
      *            by this component.
      * @return the response the to request stanza, or <tt>null</tt> to indicate
      *         'feature-not-available'.
+     * @throws Exception
+     *          if internal error occurs.
      */
     protected IQ handleIQSet(IQ iq) throws Exception {
         // Doesn't do anything. Override this method to process IQ set
@@ -615,7 +618,7 @@ public abstract class AbstractComponent implements Component {
     /**
      * Default handler of Service Discovery Info requests. Unless overridden,
      * this method returns an IQ <tt>result</tt> packet that includes:
-     * <p/>
+     * <br>
      * <ul>
      * <li>One Service Discovery 'Identity'. The attributes of the identity are
      * determined in this way:
@@ -633,7 +636,7 @@ public abstract class AbstractComponent implements Component {
      * Discovery Info' feature, and the results of
      * {@link #discoInfoFeatureNamespaces()}.</li>
      * </ul>
-     * <p/>
+     * <br>
      * Note that you should include the 'Service Discovery Items' feature if
      * {@link #handleDiscoInfo(IQ)} returns a non-null value.
      *
@@ -754,14 +757,13 @@ public abstract class AbstractComponent implements Component {
      * Returns the category of the Service Discovery Identity of this component
      * (this implementation will only hold exactly one Identity for the
      * component).
-     * <p/>
+     * <br>
      * The default Category of a component, which is used if this method is not
      * overridden, is 'component'.
      *
      * @return the category of the Service Discovery Identity of this component.
-     * @see <a *
-     *      href="http://www.xmpp.org/registrar/disco-categories.html">official
-     *      * Service Discovery Identities registry< /a>
+     * @see <a href="http://www.xmpp.org/registrar/disco-categories.html">
+     *     official Service Discovery Identities registry</a>
      */
     protected String discoInfoIdentityCategory() {
         return "component";
@@ -771,7 +773,7 @@ public abstract class AbstractComponent implements Component {
      * Returns the type of the Service Discovery Identity of this component
      * (this implementation will only hold exactly one Identity for the
      * component).
-     * <p/>
+     * <br>
      * The default Category type of a component, which is used if this method is
      * not overridden, is 'generic'.
      *
@@ -788,12 +790,12 @@ public abstract class AbstractComponent implements Component {
      * This method returns a String array that should contain all namespaces of
      * features that this component offers. The result of this method will be
      * included in Service Discovery responses.
-     * <p/>
+     * <br>
      * Note that the features that are returned by this method should also be
-     * implemented in either {@link #handleIQGet()} and/or
-     * {@link #handleIQSet()} methods. Also note that the default namespaces for
+     * implemented in either {@link #handleIQGet(IQ)} and/or
+     * {@link #handleIQSet(IQ)} methods. Also note that the default namespaces for
      * service discovery should not be returned by this method.
-     * <p/>
+     * <br>
      * The default implementation of this method returns an empty array.
      * Override this method to include new namespaces.
      *
@@ -831,7 +833,6 @@ public abstract class AbstractComponent implements Component {
      * Checks if the component can only be used by users of the XMPP domain that
      * the component has registered to. If this method returns <tt>true</tt>,
      * this will happen:
-     * <p/>
      * <ul>
      * <li>Messages and Presence stanzas are silently ignored.</li>
      * <li>IQ stanza's of type <tt>result</tt> and <tt>error</tt> are silently
@@ -839,7 +840,7 @@ public abstract class AbstractComponent implements Component {
      * <li>IQ stanza's of type <tt>get</tt> or <tt>set</tt> are responded to
      * with a IQ <tt>error</tt> response, type 'cancel', condition
      * 'not-allowed'.
-     * <p/>
+     * </ul>
      * Note that by default, this method returns <tt>false</tt>. You can
      * override this method to change the behavior.
      *
@@ -984,7 +985,7 @@ public abstract class AbstractComponent implements Component {
     /**
      * Checks if the packet was sent by an entity inside the XMPP domain of the
      * component.
-     * <p/>
+     * <br>
      * An entity is considered a local entity if the domain of its JID either
      * equals the XMPP domain, or is a subdomain of the XMPP domain.
      *

--- a/src/main/java/org/xmpp/component/Component.java
+++ b/src/main/java/org/xmpp/component/Component.java
@@ -38,14 +38,14 @@ public interface Component {
      *
      * @return the name of this component.
      */
-    public String getName();
+    String getName();
 
     /**
      * Returns the description of this component.
      *
      * @return the description of this component.
      */
-    public String getDescription();
+    String getDescription();
 
     /**
      * Processes a packet sent to this Component.
@@ -53,7 +53,7 @@ public interface Component {
      * @param packet the packet.
      * @see ComponentManager#sendPacket(Component, Packet)
      */
-    public void processPacket(Packet packet);
+    void processPacket(Packet packet);
 
     /**
      * Initializes this component with a ComponentManager and the JID
@@ -69,7 +69,7 @@ public interface Component {
      * @param componentManager the component manager.
      * @throws ComponentException if an error occured while initializing the component.
      */
-    public void initialize(JID jid, ComponentManager componentManager) throws ComponentException;
+    void initialize(JID jid, ComponentManager componentManager) throws ComponentException;
 
     /**
      * Notification message indicating that the component will start receiving incoming
@@ -78,11 +78,11 @@ public interface Component {
      *
      * It is likely that most of the component will leave this method empty.
      */
-    public void start();
+    void start();
 
     /**
      * Shuts down this component. All component resources must be released as
      * part of shutdown.
      */
-    public void shutdown();
+    void shutdown();
 }

--- a/src/main/java/org/xmpp/component/ComponentManager.java
+++ b/src/main/java/org/xmpp/component/ComponentManager.java
@@ -37,7 +37,7 @@ public interface ComponentManager {
      * @param component the component.
      * @throws ComponentException if the component connection is lost and the component cannot be added.
      */
-    public void addComponent(String subdomain, Component component) throws ComponentException;
+    void addComponent(String subdomain, Component component) throws ComponentException;
 
     /**
      * Removes a component. The {@link Component#shutdown} method will be called on the
@@ -46,7 +46,7 @@ public interface ComponentManager {
      * @param subdomain the subdomain of the component's address.
      * @throws ComponentException if the component connection is lost and the component cannot be removed.
      */
-    public void removeComponent(String subdomain) throws ComponentException;
+    void removeComponent(String subdomain) throws ComponentException;
 
     /**
      * Sends a packet to the XMPP server. The "from" value of the packet must not be null.
@@ -60,7 +60,7 @@ public interface ComponentManager {
      * @throws ComponentException if the component connection is lost or unavialble during the time of sending and
      * recieving packets.
      */
-    public void sendPacket(Component component, Packet packet) throws ComponentException;
+    void sendPacket(Component component, Packet packet) throws ComponentException;
 
     /**
      * Sends an IQ packet to the XMPP server and waits to get an IQ of type result or error.
@@ -80,7 +80,7 @@ public interface ComponentManager {
      * @throws ComponentException if the component connection is lost or unavialble during the time of sending and
      * recieving packets.
      */
-    public IQ query(Component component, IQ packet, long timeout) throws ComponentException;
+    IQ query(Component component, IQ packet, long timeout) throws ComponentException;
 
     /**
      * Sends an IQ packet to the server and returns immediately. The specified IQResultListener
@@ -92,7 +92,7 @@ public interface ComponentManager {
      * @throws ComponentException if the component connection is lost or unavialble during the time of sending and
      * recieving packets.
      */
-    public void query(Component component, IQ packet, IQResultListener listener) throws ComponentException;
+    void query(Component component, IQ packet, IQResultListener listener) throws ComponentException;
 
     /**
      * Returns a property value specified by name. Properties can be used by
@@ -104,7 +104,7 @@ public interface ComponentManager {
      * @param name the property name.
      * @return the property value.
      */
-    public String getProperty(String name);
+    String getProperty(String name);
 
     /**
      * Sets a property value. Properties can be used by components to
@@ -116,7 +116,7 @@ public interface ComponentManager {
      * @param name the property name.
      * @param value the property value.
      */
-    public void setProperty(String name, String value);
+    void setProperty(String name, String value);
 
     /**
      * Returns the domain of the XMPP server. The domain name may be the IP address or the host
@@ -124,7 +124,7 @@ public interface ComponentManager {
      *
      * @return the domain of the XMPP server.
      */
-    public String getServerName();
+    String getServerName();
 
     /**
      * Returns true if components managed by this component manager are external
@@ -133,5 +133,5 @@ public interface ComponentManager {
      *
      * @return true if the managed components are external components.
      */
-    public boolean isExternalMode();
+    boolean isExternalMode();
 }

--- a/src/main/java/org/xmpp/component/IQResultListener.java
+++ b/src/main/java/org/xmpp/component/IQResultListener.java
@@ -20,9 +20,9 @@ import org.xmpp.packet.IQ;
 
 /**
  * An IQResultListener will be invoked when a previously IQ packet sent by the server was answered.
- * Use {@link IQRouter#addIQResultListener(String, IQResultListener)} to add a new listener that
+ * Use {@code IQRouter#addIQResultListener(String, IQResultListener)} to add a new listener that
  * will process the answer to the IQ packet being sent. The listener will automatically be
- * removed from the {@link IQRouter} as soon as a reply for the sent IQ packet is received. The
+ * removed from the {@code IQRouter} as soon as a reply for the sent IQ packet is received. The
  * reply can be of type RESULT or ERROR.
  *
  * @author Gaston Dombiak

--- a/src/main/java/org/xmpp/forms/DataForm.java
+++ b/src/main/java/org/xmpp/forms/DataForm.java
@@ -39,19 +39,21 @@ import org.xmpp.util.XMPPConstants;
 /**
  * Represents a form that could be use for gathering data as well as for reporting data
  * returned from a search.
- * <p/>
+ * <p>
  * The form could be of the following types:
+ * </p>
  * <ul>
- * <li>form -> Indicates a form to fill out.</li>
- * <li>submit -> The form is filled out, and this is the data that is being returned from
+ * <li>form -&gt; Indicates a form to fill out.</li>
+ * <li>submit -&gt; The form is filled out, and this is the data that is being returned from
  * the form.</li>
- * <li>cancel -> The form was cancelled. Tell the asker that piece of information.</li>
- * <li>result -> Data results being returned from a search, or some other query.</li>
+ * <li>cancel -&gt; The form was cancelled. Tell the asker that piece of information.</li>
+ * <li>result -&gt; Data results being returned from a search, or some other query.</li>
  * </ul>
- * <p/>
+ * <p>
  * In case the form represents a search, the report will be structured in columns and rows. Use
  * {@link #addReportedField(String, String, FormField.Type)} to set the columns of the report whilst
  * the report's rows can be configured using {@link #addItemFields(Map)}.
+ * </p>
  *
  * @author Gaston Dombiak
  */
@@ -142,7 +144,7 @@ public class DataForm extends PacketExtension {
 
     /**
      * Sets the description of the data. It is similar to the title on a web page or an X window.
-     * You can put a <title/> on either a form to fill out, or a set of data results.
+     * You can put a &lt;title/&gt; on either a form to fill out, or a set of data results.
      *
      * @param title description of the data.
      */
@@ -156,7 +158,7 @@ public class DataForm extends PacketExtension {
 
     /**
      * Returns the description of the data form. It is similar to the title on a web page or an X
-     * window.  You can put a <title/> on either a form to fill out, or a set of data results.
+     * window.  You can put a &lt;title/&gt; on either a form to fill out, or a set of data results.
      *
      * @return description of the data.
      */
@@ -321,13 +323,13 @@ public class DataForm extends PacketExtension {
 
     /**
      * Adds a new row of items of reported data. For each entry in the <tt>fields</tt> parameter
-     * a <tt>field</tt> element will be added to the <item> element. The variable of the new
+     * a <tt>field</tt> element will be added to the &lt;item&gt; element. The variable of the new
      * <tt>field</tt> will be the key of the entry. The new <tt>field</tt> will have several values
      * if the entry's value is a {@link Collection}. Since the value is of type {@link Object} it
      * is possible to include any type of object as a value. The actual value to include in the
      * data form is the result of the {@link #encode(Object)} method.
      *
-     * @param fields list of <variable,value> to be added as a new item.
+     * @param fields list of &lt;variable,value&gt; to be added as a new item.
      */
     @SuppressWarnings("unchecked")
     public void addItemFields(Map<String, Object> fields) {

--- a/src/main/java/org/xmpp/forms/DataForm.java
+++ b/src/main/java/org/xmpp/forms/DataForm.java
@@ -251,7 +251,7 @@ public class DataForm extends PacketExtension {
      */
     @SuppressWarnings("unchecked")
     public List<FormField> getFields() {
-        List<FormField> answer = new ArrayList<FormField>();
+        List<FormField> answer = new ArrayList<>();
         for (Iterator<Element> it = element.elementIterator("field"); it.hasNext(); ) {
             answer.add(new FormField(it.next()));
         }

--- a/src/main/java/org/xmpp/forms/FormField.java
+++ b/src/main/java/org/xmpp/forms/FormField.java
@@ -94,7 +94,7 @@ public class FormField {
      */
     @SuppressWarnings("unchecked")
     public List<Option> getOptions() {
-        List<Option> answer = new ArrayList<Option>();
+        List<Option> answer = new ArrayList<>();
         for (Iterator<Element> it = element.elementIterator("option"); it.hasNext(); ) {
             answer.add(new Option(it.next()));
         }
@@ -103,21 +103,20 @@ public class FormField {
 
     /**
      * Sets an indicative of the format for the data to answer. Valid formats are:
-     * <p/>
      * <ul>
-     * <li>text-single -> single line or word of text
-     * <li>text-private -> instead of showing the user what they typed, you show ***** to
-     * protect it
-     * <li>text-multi -> multiple lines of text entry
-     * <li>list-single -> given a list of choices, pick one
-     * <li>list-multi -> given a list of choices, pick one or more
-     * <li>boolean -> 0 or 1, true or false, yes or no. Default value is 0
-     * <li>fixed -> fixed for putting in text to show sections, or just advertise your web
-     * site in the middle of the form
-     * <li>hidden -> is not given to the user at all, but returned with the questionnaire
-     * <li>jid-single -> Jabber ID - choosing a JID from your roster, and entering one based
-     * on the rules for a JID.
-     * <li>jid-multi -> multiple entries for JIDs
+     * <li>text-single -&gt; single line or word of text</li>
+     * <li>text-private -&gt; instead of showing the user what they typed, you show ***** to
+     * protect it</li>
+     * <li>text-multi -&gt; multiple lines of text entry</li>
+     * <li>list-single -&gt; given a list of choices, pick one</li>
+     * <li>list-multi -&gt; given a list of choices, pick one or more</li>
+     * <li>boolean -&gt; 0 or 1, true or false, yes or no. Default value is 0</li>
+     * <li>fixed -&gt; fixed for putting in text to show sections, or just advertise your web
+     * site in the middle of the form</li>
+     * <li>hidden -&gt; is not given to the user at all, but returned with the questionnaire</li>
+     * <li>jid-single -&gt; Jabber ID - choosing a JID from your roster, and entering one based
+     * on the rules for a JID.</li>
+     * <li>jid-multi -&gt; multiple entries for JIDs</li>
      * </ul>
      *
      * @param type an indicative of the format for the data to answer.
@@ -164,12 +163,14 @@ public class FormField {
     /**
      * Sets a description that provides extra clarification about the question. This information
      * could be presented to the user either in tool-tip, help button, or as a section of text
-     * before the question.<p>
-     * <p/>
+     * before the question.
+     * <p>
      * If the question is of type FIXED then the description should remain empty.
+     * </p>
      * <p>
      * No new description will be set, if the provided argument is <tt>null</tt> or an empty
      * String (although an existing description will be removed).
+     * </p>
      *
      * @param description provides extra clarification about the question.
      */
@@ -237,21 +238,20 @@ public class FormField {
 
     /**
      * Returns an indicative of the format for the data to answer. Valid formats are:
-     * <p/>
      * <ul>
-     * <li>text-single -> single line or word of text
-     * <li>text-private -> instead of showing the user what they typed, you show ***** to
-     * protect it
-     * <li>text-multi -> multiple lines of text entry
-     * <li>list-single -> given a list of choices, pick one
-     * <li>list-multi -> given a list of choices, pick one or more
-     * <li>boolean -> 0 or 1, true or false, yes or no. Default value is 0
-     * <li>fixed -> fixed for putting in text to show sections, or just advertise your web
-     * site in the middle of the form
-     * <li>hidden -> is not given to the user at all, but returned with the questionnaire
-     * <li>jid-single -> Jabber ID - choosing a JID from your roster, and entering one based
-     * on the rules for a JID.
-     * <li>jid-multi -> multiple entries for JIDs
+     * <li>text-single -&gt; single line or word of text</li>
+     * <li>text-private -&gt; instead of showing the user what they typed, you show ***** to
+     * protect it</li>
+     * <li>text-multi -&gt; multiple lines of text entry</li>
+     * <li>list-single -&gt; given a list of choices, pick one</li>
+     * <li>list-multi -&gt; given a list of choices, pick one or more</li>
+     * <li>boolean -&gt; 0 or 1, true or false, yes or no. Default value is 0</li>
+     * <li>fixed -&gt; fixed for putting in text to show sections, or just advertise your web
+     * site in the middle of the form</li>
+     * <li>hidden -&gt; is not given to the user at all, but returned with the questionnaire</li>
+     * <li>jid-single -&gt; Jabber ID - choosing a JID from your roster, and entering one based
+     * on the rules for a JID.</li>
+     * <li>jid-multi -&gt; multiple entries for JIDs</li>
      * </ul>
      *
      * @return format for the data to answer.
@@ -277,9 +277,10 @@ public class FormField {
     /**
      * Returns a description that provides extra clarification about the question. This information
      * could be presented to the user either in tool-tip, help button, or as a section of text
-     * before the question.<p>
-     * <p/>
+     * before the question.
+     * <p>
      * If the question is of type FIXED then the description should remain empty.
+     * </p>
      *
      * @return description that provides extra clarification about the question.
      */
@@ -347,9 +348,9 @@ public class FormField {
 
         /**
          * The field is intended for data description (e.g., human-readable text such as
-         * "section" headers) rather than data gathering or provision. The <value/> child
+         * "section" headers) rather than data gathering or provision. The &lt;value/&gt; child
          * SHOULD NOT contain newlines (the \n and \r characters); instead an application
-         * SHOULD generate multiple fixed fields, each with one <value/> child.
+         * SHOULD generate multiple fixed fields, each with one &lt;value/&gt; child.
          */
         fixed("fixed"),
 

--- a/src/main/java/org/xmpp/muc/RoomConfiguration.java
+++ b/src/main/java/org/xmpp/muc/RoomConfiguration.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
  *
  * Code example:
  * <pre>
+ * {@code
  * // Set the fields and the values.
  * Map<String,Collection<String>> fields = new HashMap<String,Collection<String>>();
  * // Make a non-public room
@@ -45,6 +46,7 @@ import java.util.Map.Entry;
  * conf.setFrom("john@jabber.org/notebook");
  *
  * component.sendPacket(conf);
+ * }
  * </pre>
  *
  * @author Gaston Dombiak

--- a/src/main/java/org/xmpp/packet/IQ.java
+++ b/src/main/java/org/xmpp/packet/IQ.java
@@ -52,7 +52,7 @@ public class IQ extends Packet {
      */
     public IQ() {
         this.element = docFactory.createDocument().addElement("iq");
-        String id = String.valueOf(random.nextInt(1000) + "-" + sequence++);
+        String id = random.nextInt(1000) + "-" + sequence++;
         setType(Type.get);
         setID(id);
     }
@@ -66,7 +66,7 @@ public class IQ extends Packet {
     public IQ(Type type) {
         this.element = docFactory.createDocument().addElement("iq");
         setType(type);
-        String id = String.valueOf(random.nextInt(1000) + "-" + sequence++);
+        String id = random.nextInt(1000) + "-" + sequence++;
         setID(id);
     }
 
@@ -185,8 +185,7 @@ public class IQ extends Packet {
             return null;
         } else {
             // Search for a child element that is in a different namespace.
-            for (int i = 0; i < elements.size(); i++) {
-                Element element = elements.get(i);
+            for (Element element : elements) {
                 String namespace = element.getNamespaceURI();
                 if (!namespace.equals("") && !namespace.equals("jabber:client") &&
                     !namespace.equals("jabber:server")) {
@@ -306,10 +305,8 @@ public class IQ extends Packet {
             Class<? extends PacketExtension> extensionClass = PacketExtension.getExtensionClass(name, namespace);
             if (extensionClass != null) {
                 try {
-                    Constructor<? extends PacketExtension> constructor = extensionClass.getDeclaredConstructor(new Class[] {
-                        Element.class});
-                    return constructor.newInstance(new Object[] {
-                        extensions.get(0)});
+                    Constructor<? extends PacketExtension> constructor = extensionClass.getDeclaredConstructor(Element.class);
+                    return constructor.newInstance(extensions.get(0));
                 } catch (Exception e) {
                     Log.warn("Packet extension (name " + name + ", namespace " + namespace + ") cannot be found.", e);
                 }

--- a/src/main/java/org/xmpp/packet/JID.java
+++ b/src/main/java/org/xmpp/packet/JID.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2004-2009 Jive Software. All rights reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,7 +37,7 @@ import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap.Builder;
  * required. In simple ABNF form:
  *
  * <ul>
- * <tt>jid = [ node "@" ] domain [ "/" resource ]</tt>
+ * <li>jid = [ node "@" ] domain [ "/" resource ]</li>
  * </ul>
  *
  * Some sample JID's:
@@ -79,13 +79,13 @@ public class JID implements Comparable<JID>, Serializable {
     /**
      * Escapes the node portion of a JID according to "JID Escaping" (XEP-0106).
      * Escaping replaces characters prohibited by node-prep with escape sequences,
-     * as follows:<p>
+     * as follows:
      *
-     * <table border="1">
+     * <table border="1" summary="Escaping rules">
      * <tr><td><b>Unescaped Character</b></td><td><b>Encoded Sequence</b></td></tr>
      * <tr><td>&lt;space&gt;</td><td>\20</td></tr>
      * <tr><td>"</td><td>\22</td></tr>
-     * <tr><td>&</td><td>\26</td></tr>
+     * <tr><td>&amp;</td><td>\26</td></tr>
      * <tr><td>'</td><td>\27</td></tr>
      * <tr><td>/</td><td>\2f</td></tr>
      * <tr><td>:</td><td>\3a</td></tr>
@@ -93,16 +93,19 @@ public class JID implements Comparable<JID>, Serializable {
      * <tr><td>&gt;</td><td>\3e</td></tr>
      * <tr><td>@</td><td>\40</td></tr>
      * <tr><td>\</td><td>\5c</td></tr>
-     * </table><p>
+     * </table>
      *
+     * <p>
      * This process is useful when the node comes from an external source that doesn't
      * conform to nodeprep. For example, a username in LDAP may be "Joe Smith". Because
      * the &lt;space&gt; character isn't a valid part of a node, the username should
      * be escaped to "Joe\20Smith" before being made into a JID (e.g. "joe\20smith@example.com"
-     * after case-folding, etc. has been applied).<p>
-     *
+     * after case-folding, etc. has been applied).
+     * </p>
+     * <p>
      * All node escaping and un-escaping must be performed manually at the appropriate
      * time; the JID class will not escape or un-escape automatically.
+     * </p>
      *
      * @param node the node.
      * @return the escaped version of the node.
@@ -167,13 +170,12 @@ public class JID implements Comparable<JID>, Serializable {
     /**
      * Un-escapes the node portion of a JID according to "JID Escaping" (XEP-0106).<p>
      * Escaping replaces characters prohibited by node-prep with escape sequences,
-     * as follows:<p>
-     *
-     * <table border="1">
+     * as follows:
+     * <table border="1" summary="Escaped characters">
      * <tr><td><b>Unescaped Character</b></td><td><b>Encoded Sequence</b></td></tr>
      * <tr><td>&lt;space&gt;</td><td>\20</td></tr>
      * <tr><td>"</td><td>\22</td></tr>
-     * <tr><td>&</td><td>\26</td></tr>
+     * <tr><td>&amp;</td><td>\26</td></tr>
      * <tr><td>'</td><td>\27</td></tr>
      * <tr><td>/</td><td>\2f</td></tr>
      * <tr><td>:</td><td>\3a</td></tr>
@@ -181,16 +183,18 @@ public class JID implements Comparable<JID>, Serializable {
      * <tr><td>&gt;</td><td>\3e</td></tr>
      * <tr><td>@</td><td>\40</td></tr>
      * <tr><td>\</td><td>\5c</td></tr>
-     * </table><p>
-     *
+     * </table>
+     * <p>
      * This process is useful when the node comes from an external source that doesn't
      * conform to nodeprep. For example, a username in LDAP may be "Joe Smith". Because
      * the &lt;space&gt; character isn't a valid part of a node, the username should
      * be escaped to "Joe\20Smith" before being made into a JID (e.g. "joe\20smith@example.com"
-     * after case-folding, etc. has been applied).<p>
-     *
+     * after case-folding, etc. has been applied).
+     * </p>
+     * <p>
      * All node escaping and un-escaping must be performed manually at the appropriate
      * time; the JID class will not escape or un-escape automatically.
+     * </p>
      *
      * @param node the escaped version of the node.
      * @return the un-escaped version of the node.
@@ -353,6 +357,8 @@ public class JID implements Comparable<JID>, Serializable {
      *             exception wraps an UnsupportedEncodingException.
      * @throws IllegalArgumentException
      *             if <tt>domain</tt> is not a valid JID domain part.
+     * @throws StringprepException
+     *             If the resource name cannot be prepped with this profile.
      */
     public static String domainprep(String domain) throws StringprepException {
         if (domain == null) {
@@ -426,6 +432,8 @@ public class JID implements Comparable<JID>, Serializable {
      *             exception wraps an UnsupportedEncodingException.
      * @throws IllegalArgumentException
      *             if <tt>resource</tt> is not a valid JID resource.
+     * @throws StringprepException
+     *             If the resource name cannot be prepped with this profile.
      */
     public static String resourceprep(String resource) throws StringprepException {
         if (resource == null) {

--- a/src/main/java/org/xmpp/packet/JID.java
+++ b/src/main/java/org/xmpp/packet/JID.java
@@ -21,7 +21,6 @@ import gnu.inet.encoding.Stringprep;
 import gnu.inet.encoding.StringprepException;
 
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentMap;
 
@@ -303,7 +302,7 @@ public class JID implements Comparable<JID>, Serializable {
                 }
             } catch (Exception ex) {
                 // register the failure in the cache (TINDER-24)
-                NODEPREP_CACHE.put(node, new ValueWrapper<String>(
+                NODEPREP_CACHE.put(node, new ValueWrapper<>(
                     Representation.ILLEGAL));
                 throw new IllegalArgumentException("The input is not a valid JID node: " + node, ex);
             }
@@ -311,12 +310,12 @@ public class JID implements Comparable<JID>, Serializable {
             // Add the result to the cache. As most key/value pairs will contain
             // equal Strings, we use an identifier object to represent this
             // state.
-            NODEPREP_CACHE.put(answer, new ValueWrapper<String>(
+            NODEPREP_CACHE.put(answer, new ValueWrapper<>(
                 Representation.USE_KEY));
             if (!node.equals(answer)) {
                 // If the input differs from the stringprepped result, include
                 // the raw input as a key too. (TINDER-24)
-                NODEPREP_CACHE.put(node, new ValueWrapper<String>(answer));
+                NODEPREP_CACHE.put(node, new ValueWrapper<>(answer));
             }
         } else {
             switch (cachedResult.getRepresentation()) {
@@ -375,7 +374,7 @@ public class JID implements Comparable<JID>, Serializable {
                 }
             } catch (Exception ex) {
                 // register the failure in the cache (TINDER-24)
-                DOMAINPREP_CACHE.put(domain, new ValueWrapper<String>(
+                DOMAINPREP_CACHE.put(domain, new ValueWrapper<>(
                     Representation.ILLEGAL));
                 throw new IllegalArgumentException("The input is not a valid JID domain part: " + domain, ex);
             }
@@ -383,12 +382,12 @@ public class JID implements Comparable<JID>, Serializable {
             // Add the result to the cache. As most key/value pairs will contain
             // equal Strings, we use an identifier object to represent this
             // state.
-            DOMAINPREP_CACHE.put(answer, new ValueWrapper<String>(
+            DOMAINPREP_CACHE.put(answer, new ValueWrapper<>(
                 Representation.USE_KEY));
             if (!domain.equals(answer)) {
                 // If the input differs from the stringprepped result, include
                 // the raw input as a key too. (TINDER-24)
-                DOMAINPREP_CACHE.put(domain, new ValueWrapper<String>(answer));
+                DOMAINPREP_CACHE.put(domain, new ValueWrapper<>(answer));
             }
         } else {
             switch (cachedResult.getRepresentation()) {
@@ -428,8 +427,7 @@ public class JID implements Comparable<JID>, Serializable {
      * @throws IllegalArgumentException
      *             if <tt>resource</tt> is not a valid JID resource.
      */
-    public static String resourceprep(String resource)
-        throws StringprepException {
+    public static String resourceprep(String resource) throws StringprepException {
         if (resource == null) {
             return null;
         }
@@ -450,7 +448,7 @@ public class JID implements Comparable<JID>, Serializable {
                 }
             } catch (Exception ex) {
                 // register the failure in the cache (TINDER-24)
-                RESOURCEPREP_CACHE.put(resource, new ValueWrapper<String>(
+                RESOURCEPREP_CACHE.put(resource, new ValueWrapper<>(
                     Representation.ILLEGAL));
                 throw new IllegalArgumentException("The input is not a valid JID resource: " + resource, ex);
             }
@@ -458,12 +456,12 @@ public class JID implements Comparable<JID>, Serializable {
             // Add the result to the cache. As most key/value pairs will contain
             // equal Strings, we use an identifier object to represent this
             // state.
-            RESOURCEPREP_CACHE.put(answer, new ValueWrapper<String>(
+            RESOURCEPREP_CACHE.put(answer, new ValueWrapper<>(
                 Representation.USE_KEY));
             if (!resource.equals(answer)) {
                 // If the input differs from the stringprepped result, include
                 // the raw input as a key too. (TINDER-24)
-                RESOURCEPREP_CACHE.put(resource, new ValueWrapper<String>(
+                RESOURCEPREP_CACHE.put(resource, new ValueWrapper<>(
                     answer));
             }
         } else {
@@ -612,7 +610,7 @@ public class JID implements Comparable<JID>, Serializable {
         }
 
         // Domain
-        String domain = null;
+        String domain;
         if (atIndex + 1 > jid.length()) {
             throw new IllegalArgumentException("JID with empty domain not valid. Offending value: '" + jid + "'");
         }
@@ -631,7 +629,7 @@ public class JID implements Comparable<JID>, Serializable {
         }
 
         // Resource
-        String resource = null;
+        String resource;
         if (slashIndex + 1 > jid.length() || slashIndex < 0) {
             resource = null;
         } else {
@@ -723,10 +721,8 @@ public class JID implements Comparable<JID>, Serializable {
             sb.append('@');
         }
         sb.append(this.domain);
-        if (this.resource != null) {
-            sb.append('/');
-            sb.append(this.resource);
-        }
+        sb.append('/');
+        sb.append(this.resource);
 
         return sb.toString();
     }

--- a/src/main/java/org/xmpp/packet/Message.java
+++ b/src/main/java/org/xmpp/packet/Message.java
@@ -23,13 +23,12 @@ import org.dom4j.Element;
 import java.util.Iterator;
 
 /**
- * Message packet.<p>
- *
+ * Message packet.
+ * <p>
  * A message can have one of several {@link Type Types}. For each message type,
  * different message fields are typically used as follows:
- *
- * <p>
- * <table border="1">
+ * </p>
+ * <table border="1" summary="Messages">
  * <tr><td>&nbsp;</td><td colspan="5"><b>Message type</b></td></tr>
  * <tr><td><i>Field</i></td><td><b>Normal</b></td><td><b>Chat</b></td><td><b>Group Chat</b></td><td><b>Headline</b></td><td><b>Error</b></td></tr>
  * <tr><td><i>subject</i></td> <td>SHOULD</td><td>SHOULD NOT</td><td>SHOULD NOT</td><td>SHOULD NOT</td><td>SHOULD NOT</td></tr>

--- a/src/main/java/org/xmpp/packet/PacketError.java
+++ b/src/main/java/org/xmpp/packet/PacketError.java
@@ -409,7 +409,7 @@ public class PacketError {
         /**
          * The recipient or server can no longer be contacted at this address
          * (the error stanza MAY contain a new address in the XML character
-         * data of the <gone/> element); the associated error type SHOULD be
+         * data of the &lt;gone/&gt; element); the associated error type SHOULD be
          * "modify".
          */
         gone("gone", Type.modify, 302),

--- a/src/main/java/org/xmpp/packet/PacketExtension.java
+++ b/src/main/java/org/xmpp/packet/PacketExtension.java
@@ -47,7 +47,7 @@ public class PacketExtension {
      * Subclasses of PacketExtension should register the element name and namespace that the
      * subclass is using.
      */
-    protected static final Map<QName, Class<? extends PacketExtension>> registeredExtensions = new ConcurrentHashMap<QName, Class<? extends PacketExtension>>();
+    protected static final Map<QName, Class<? extends PacketExtension>> registeredExtensions = new ConcurrentHashMap<>();
 
     protected Element element;
 

--- a/src/main/java/org/xmpp/packet/Presence.java
+++ b/src/main/java/org/xmpp/packet/Presence.java
@@ -95,7 +95,7 @@ public class Presence extends Packet {
      * convenience method that is equivalent to:
      *
      * <pre>getType() == null</pre>
-     *
+     * @return true if presense type is "available" else false.
      */
     public boolean isAvailable() {
         return getType() == null;

--- a/src/main/java/org/xmpp/packet/StreamError.java
+++ b/src/main/java/org/xmpp/packet/StreamError.java
@@ -328,7 +328,7 @@ public class StreamError {
 
         /**
          * The entity has violated some local service policy; the server MAY choose to
-         * specify the policy in the <text/> element or an application-specific condition
+         * specify the policy in the &lt;text/&gt; element or an application-specific condition
          * element.
          */
         policy_violation("policy-violation"),
@@ -393,7 +393,8 @@ public class StreamError {
          * The initiating entity has sent XML that is not well-formed.
          *
          * @deprecated Deprecated by RFC6120 in favor of "not_well_formed"
-         * @see http://xmpp.org/rfcs/rfc6120.html#streams-error-conditions-not-well-formed
+         * @see <a href="http://xmpp.org/rfcs/rfc6120.html#streams-error-conditions-not-well-formed">
+         *     http://xmpp.org/rfcs/rfc6120.html#streams-error-conditions-not-well-formed</a>
          */
         @Deprecated
         xml_not_well_formed("xml-not-well-formed"),

--- a/src/main/java/org/xmpp/resultsetmanagement/Result.java
+++ b/src/main/java/org/xmpp/resultsetmanagement/Result.java
@@ -33,12 +33,12 @@ public interface Result {
      * Returns a unique identifier for this Result. Each element in a ResultSet
      * must have a distinct UIDs.
      *
-     * XEP-0059 says: <quote>(...) the UIDs are
+     * XEP-0059 says: <blockquote>(...) the UIDs are
      * unique in the context of all possible members of the full result set.
      * Each UID MAY be based on part of the content of its associated item (...)
      * or on an internal table index. Another possible method is to serialize
      * the XML of the item and then hash it to generate the UID. Note: The
-     * requesting entity MUST treat all UIDs as opaque.</quote>
+     * requesting entity MUST treat all UIDs as opaque.</blockquote>
      *
      * @return Unique ID of the Result
      */

--- a/src/main/java/org/xmpp/resultsetmanagement/ResultSet.java
+++ b/src/main/java/org/xmpp/resultsetmanagement/ResultSet.java
@@ -44,7 +44,7 @@ public abstract class ResultSet<E extends Result> extends AbstractCollection<E> 
     /**
      * A list of field names that are valid in jabber:iq:search
      */
-    private final static Collection<String> validRequestFields = new ArrayList<String>();
+    private final static Collection<String> validRequestFields = new ArrayList<>();
 
     static {
         validRequestFields.add("max"); // required


### PR DESCRIPTION
Use diamond operator.
Use foreach loop.
Remove redundant casts.
Remove public modifier in interfaces.
Enable doclint.
Fix javadocs errors.
Setup source encoding to UTF-8.