### PR TITLE
Use <code> instead of <tt> for Javadoc

### DIFF
--- a/src/main/java/org/xmpp/component/AbstractComponent.java
+++ b/src/main/java/org/xmpp/component/AbstractComponent.java
@@ -58,15 +58,15 @@ import org.xmpp.util.XMPPConstants;
  * (internal-server-error/wait) will be returned.
  *
  * By default, instances of this class are guaranteed to return an IQ response
- * on every consumed IQ of the <tt>get</tt> or <tt>set</tt> type, as required by
+ * on every consumed IQ of the <code>get</code> or <code>set</code> type, as required by
  * the XMPP specification. If the abstract component cannot formulate a valid
  * response and the extending implementation does not provide a response either
- * (by returning <tt>null</tt> on invocations of {@link #handleIQGet(IQ)} and
+ * (by returning <code>null</code> on invocations of {@link #handleIQGet(IQ)} and
  * {@link #handleIQSet(IQ)}) an IQ error response is returned.
  *
  * The behavior described above can be disabled by setting a corresponding flag
  * in one of the constructors. If an instance is configured in such a way,
- * <tt>null</tt> responses provided by the extending implementation are not
+ * <code>null</code> responses provided by the extending implementation are not
  * translated in an IQ error. This allows the extending implementation to
  * respond to IQ requests in an asynchrous manner. It will be up to the
  * extending implementation to ensure that every IQ request is responded to.
@@ -145,7 +145,7 @@ public abstract class AbstractComponent implements Component {
     private final int maxQueueSize;
 
     /**
-     * if <tt>true</tt>, the component will make sure that every request that is
+     * if <code>true</code>, the component will make sure that every request that is
      * received is answered, as specified by the XMPP specification.
      */
     private final boolean enforceIQResult;
@@ -173,7 +173,7 @@ public abstract class AbstractComponent implements Component {
      *            capacity of the queue that holds tasks that are to be executed
      *            by the thread pool.
      * @param enforceIQResult
-     *            if <tt>true</tt>, the component will make sure that every
+     *            if <code>true</code>, the component will make sure that every
      *            request that is received is answered, as specified by the XMPP
      *            specification.
      */
@@ -249,16 +249,16 @@ public abstract class AbstractComponent implements Component {
      * method:
      * <br>
      * <ul>
-     * <li>calls methods to process IQ requests (type <tt>get</tt> and
-     * <tt>set</tt>). If no response to these request are returned, this method
-     * will respond to the request with an IQ stanza of type <tt>error</tt>,
-     * containing an error condition <tt>feature-not-implemented</tt> (this
-     * behavior can be disabled by setting the <tt>enforceIQResult</tt> argument
-     * in the constructor to <tt>false</tt>);</li>
-     * <li>calls methods to process IQ results (type <tt>result</tt> and
-     * <tt>error</tt>). No response to these stanzas are expected;</li>
+     * <li>calls methods to process IQ requests (type <code>get</code> and
+     * <code>set</code>). If no response to these request are returned, this method
+     * will respond to the request with an IQ stanza of type <code>error</code>,
+     * containing an error condition <code>feature-not-implemented</code> (this
+     * behavior can be disabled by setting the <code>enforceIQResult</code> argument
+     * in the constructor to <code>false</code>);</li>
+     * <li>calls methods to process IQ results (type <code>result</code> and
+     * <code>error</code>). No response to these stanzas are expected;</li>
      * <li>returns an IQ stanza of type error, condition 'internal-server-error'
-     * if the processing of an IQ request (type <tt>get</tt> or <tt>set</tt>)
+     * if the processing of an IQ request (type <code>get</code> or <code>set</code>)
      * resulted in an Exception being thrown.</li>
      * </ul>
      * <br>
@@ -430,12 +430,12 @@ public abstract class AbstractComponent implements Component {
     }
 
     /**
-     * Processes IQ request stanzas (IQ stanzas of type <tt>get</tt> or
-     * <tt>set</tt>. This method will, in order:
+     * Processes IQ request stanzas (IQ stanzas of type <code>get</code> or
+     * <code>set</code>. This method will, in order:
      * <br>
      * <ol>
      * <li>check if the stanza is a valid request stanza. If not, an IQ stanza
-     * of type <tt>error</tt>, condition 'bad-request' is returned;</li>
+     * of type <code>error</code>, condition 'bad-request' is returned;</li>
      * <li>process Service Discovery requests by calling
      * {@link #handleDiscoInfo(IQ)} and {@link #handleDiscoItems(IQ)} where
      * appropriate;</li>
@@ -444,14 +444,14 @@ public abstract class AbstractComponent implements Component {
      * </li>
      * </ol>
      * <br>
-     * Note that if this method returns <tt>null</tt>, an IQ stanza of type
-     * <tt>error</tt>, condition <tt>feature-not-implemented</tt> will be
+     * Note that if this method returns <code>null</code>, an IQ stanza of type
+     * <code>error</code>, condition <code>feature-not-implemented</code> will be
      * returned to the sender of the original request. This behavior can be
-     * disabled by setting the <tt>enforceIQResult</tt> argument in the
-     * constructor to <tt>false</tt>.
+     * disabled by setting the <code>enforceIQResult</code> argument in the
+     * constructor to <code>false</code>.
      * <br>
      * Note that if this method throws an Exception, an IQ stanza of type
-     * <tt>error</tt>, condition 'internal-server-error' will be returned to the
+     * <code>error</code>, condition 'internal-server-error' will be returned to the
      * sender of the original request.
      * <br>
      * Note that if you want to add or adjust functionality, you should
@@ -530,12 +530,12 @@ public abstract class AbstractComponent implements Component {
     }
 
     /**
-     * Override this method to handle the IQ stanzas of type <tt>result</tt>
+     * Override this method to handle the IQ stanzas of type <code>result</code>
      * that are received by the component. If you do not override this method,
      * the stanzas are ignored.
      *
      * @param iq
-     *            The IQ stanza of type <tt>result</tt> that was received by
+     *            The IQ stanza of type <code>result</code> that was received by
      *            this component.
      */
     protected void handleIQResult(IQ iq) {
@@ -544,12 +544,12 @@ public abstract class AbstractComponent implements Component {
     }
 
     /**
-     * Override this method to handle the IQ stanzas of type <tt>error</tt> that
+     * Override this method to handle the IQ stanzas of type <code>error</code> that
      * are received by the component. If you do not override this method, the
      * stanzas are ignored.
      *
      * @param iq
-     *            The IQ stanza of type <tt>error</tt> that was received by this
+     *            The IQ stanza of type <code>error</code> that was received by this
      *            component.
      */
     protected void handleIQError(IQ iq) {
@@ -562,26 +562,26 @@ public abstract class AbstractComponent implements Component {
     }
 
     /**
-     * Override this method to handle the IQ stanzas of type <tt>get</tt> that
+     * Override this method to handle the IQ stanzas of type <code>get</code> that
      * could not be processed by the {@link AbstractComponent} implementation.
      * <br>
-     * Note that, as any IQ stanza of type <tt>get</tt> must be replied to,
-     * returning <tt>null</tt> from this method equals returning an IQ error
+     * Note that, as any IQ stanza of type <code>get</code> must be replied to,
+     * returning <code>null</code> from this method equals returning an IQ error
      * stanza of type 'feature-not-implemented' (this behavior can be disabled
-     * by setting the <tt>enforceIQResult</tt> argument in the constructor to
-     * <tt>false</tt>).
+     * by setting the <code>enforceIQResult</code> argument in the constructor to
+     * <code>false</code>).
      * <br>
      * Note that if this method throws an Exception, an IQ stanza of type
-     * <tt>error</tt>, condition 'internal-server-error' will be returned to the
+     * <code>error</code>, condition 'internal-server-error' will be returned to the
      * sender of the original request.
      * <br>
-     * The default implementation of this method returns <tt>null</tt>. It is
+     * The default implementation of this method returns <code>null</code>. It is
      * expected that most child classes will override this method.
      *
      * @param iq
-     *            The IQ request stanza of type <tt>get</tt> that was received
+     *            The IQ request stanza of type <code>get</code> that was received
      *            by this component.
-     * @return the response the to request stanza, or <tt>null</tt> to indicate
+     * @return the response the to request stanza, or <code>null</code> to indicate
      *         'feature-not-available'.
      * @throws Exception
      *          if internal error occurs.
@@ -593,26 +593,26 @@ public abstract class AbstractComponent implements Component {
     }
 
     /**
-     * Override this method to handle the IQ stanzas of type <tt>set</tt> that
+     * Override this method to handle the IQ stanzas of type <code>set</code> that
      * could not be processed by the {@link AbstractComponent} implementation.
      * <br>
-     * Note that, as any IQ stanza of type <tt>set</tt> must be replied to,
-     * returning <tt>null</tt> from this method equals returning an IQ error
+     * Note that, as any IQ stanza of type <code>set</code> must be replied to,
+     * returning <code>null</code> from this method equals returning an IQ error
      * stanza of type 'feature-not-implemented' {this behavior can be disabled
-     * by setting the <tt>enforceIQResult</tt> argument in the constructor to
-     * <tt>false</tt>).
+     * by setting the <code>enforceIQResult</code> argument in the constructor to
+     * <code>false</code>).
      * <br>
      * Note that if this method throws an Exception, an IQ stanza of type
-     * <tt>error</tt>, condition 'internal-server-error' will be returned to the
+     * <code>error</code>, condition 'internal-server-error' will be returned to the
      * sender of the original request.
      * <br>
-     * The default implementation of this method returns <tt>null</tt>. It is
+     * The default implementation of this method returns <code>null</code>. It is
      * expected that most child classes will override this method.
      *
      * @param iq
-     *            The IQ request stanza of type <tt>set</tt> that was received
+     *            The IQ request stanza of type <code>set</code> that was received
      *            by this component.
-     * @return the response the to request stanza, or <tt>null</tt> to indicate
+     * @return the response the to request stanza, or <code>null</code> to indicate
      *         'feature-not-available'.
      * @throws Exception
      *          if internal error occurs.
@@ -625,7 +625,7 @@ public abstract class AbstractComponent implements Component {
 
     /**
      * Default handler of Service Discovery Info requests. Unless overridden,
-     * this method returns <tt>null</tt>, which will result into a
+     * this method returns <code>null</code>, which will result into a
      * 'service-unavailable' response to be returned as a response to the
      * original request.
      *
@@ -639,7 +639,7 @@ public abstract class AbstractComponent implements Component {
 
     /**
      * Default handler of Service Discovery Info requests. Unless overridden,
-     * this method returns an IQ <tt>result</tt> packet that includes:
+     * this method returns an IQ <code>result</code> packet that includes:
      * <br>
      * <ul>
      * <li>One Service Discovery 'Identity'. The attributes of the identity are
@@ -759,7 +759,7 @@ public abstract class AbstractComponent implements Component {
      * address of this component should be a subdomain of the domain returned by
      * this method.
      *
-     * @return The XMPP domain name, or <tt>null</tt> if this component has not been initialized yet.
+     * @return The XMPP domain name, or <code>null</code> if this component has not been initialized yet.
      */
     public String getDomain() {
         return jid != null ? jid.getDomain() : null;
@@ -768,7 +768,7 @@ public abstract class AbstractComponent implements Component {
     /**
      * Returns the XMPP address / Jabber ID (JID) of this component.
      *
-     * @return The JID of this component, or <tt>null</tt> if this component has
+     * @return The JID of this component, or <code>null</code> if this component has
      *         not been initialized yet.
      */
     public JID getJID() {
@@ -853,21 +853,21 @@ public abstract class AbstractComponent implements Component {
 
     /**
      * Checks if the component can only be used by users of the XMPP domain that
-     * the component has registered to. If this method returns <tt>true</tt>,
+     * the component has registered to. If this method returns <code>true</code>,
      * this will happen:
      * <ul>
      * <li>Messages and Presence stanzas are silently ignored.</li>
-     * <li>IQ stanza's of type <tt>result</tt> and <tt>error</tt> are silently
+     * <li>IQ stanza's of type <code>result</code> and <code>error</code> are silently
      * ignored.</li>
-     * <li>IQ stanza's of type <tt>get</tt> or <tt>set</tt> are responded to
-     * with a IQ <tt>error</tt> response, type 'cancel', condition
+     * <li>IQ stanza's of type <code>get</code> or <code>set</code> are responded to
+     * with a IQ <code>error</code> response, type 'cancel', condition
      * 'not-allowed'.
      * </ul>
-     * Note that by default, this method returns <tt>false</tt>. You can
+     * Note that by default, this method returns <code>false</code>. You can
      * override this method to change the behavior.
      *
-     * @return <tt>true</tt> if this component serves local users only, <tt>
-     *         false</tt> otherwise.
+     * @return <code>true</code> if this component serves local users only, <code>
+     *         false</code> otherwise.
      */
     public boolean servesLocalUsersOnly() {
         return false;
@@ -885,7 +885,7 @@ public abstract class AbstractComponent implements Component {
 
     /**
      * Cleans up the queue, by dropping all packets from the queue. Queued IQ
-     * stanzas of type <tt>get</tt> and <tt>set</tt> are responded to by a
+     * stanzas of type <code>get</code> and <code>set</code> are responded to by a
      * 'recipient-unavailable' error, to indicate that this component is
      * temporarily unavailable.
      */
@@ -1015,8 +1015,8 @@ public abstract class AbstractComponent implements Component {
      *
      * @param packet
      *            The packet for which to send the sender.
-     * @return <tt>true</tt> if the stanza was sent by something inside the
-     *         local XMPP domain, <tt>false</tt> otherwise.
+     * @return <code>true</code> if the stanza was sent by something inside the
+     *         local XMPP domain, <code>false</code> otherwise.
      */
     private boolean sentByLocalEntity(final Packet packet) {
         final JID from = packet.getFrom();

--- a/src/main/java/org/xmpp/component/Component.java
+++ b/src/main/java/org/xmpp/component/Component.java
@@ -22,11 +22,11 @@ import org.xmpp.packet.Packet;
 /**
  * Components enhance the functionality of an XMPP server. Components receive
  * all packets addressed to a particular sub-domain. For example,
- * <tt>test_component.example.com</tt>. So, a packet sent to
- * <tt>joe@test_component.example.com</tt> would be delivered to the component.
+ * <code>test_component.example.com</code>. So, a packet sent to
+ * <code>joe@test_component.example.com</code> would be delivered to the component.
  * Note that the sub-domains defined as components are unrelated to DNS entries
  * for sub-domains. All XMPP routing at the socket level is done using the
- * primary server domain (<tt>example.com</tt> in the example above); sub-domains are
+ * primary server domain (<code>example.com</code> in the example above); sub-domains are
  * only used for routing within the XMPP server.
  *
  * @author Matt Tucker
@@ -57,7 +57,7 @@ public interface Component {
 
     /**
      * Initializes this component with a ComponentManager and the JID
-     * that this component is available at (e.g. <tt>service.example.com</tt>). If a
+     * that this component is available at (e.g. <code>service.example.com</code>). If a
      * ComponentException is thrown then the component will not be loaded.<p>
      *
      * The initialization code must not rely on receiving packets from the server since

--- a/src/main/java/org/xmpp/component/ComponentManager.java
+++ b/src/main/java/org/xmpp/component/ComponentManager.java
@@ -50,7 +50,7 @@ public interface ComponentManager {
 
     /**
      * Sends a packet to the XMPP server. The "from" value of the packet must not be null.
-     * An <tt>IllegalArgumentException</tt> will be thrown when the "from" value is null.<p>
+     * An <code>IllegalArgumentException</code> will be thrown when the "from" value is null.<p>
      *
      * Components are trusted by the server and may use any value in from address. Usually
      * the from address uses the component's address as the domain but this is not required.
@@ -64,10 +64,10 @@ public interface ComponentManager {
 
     /**
      * Sends an IQ packet to the XMPP server and waits to get an IQ of type result or error.
-     * The "from" value of the packet must not be null. An <tt>IllegalArgumentException</tt>
+     * The "from" value of the packet must not be null. An <code>IllegalArgumentException</code>
      * will be thrown when the "from" value is null.<p>
      *
-     * If no answer is received from the server before the specified timeout then <tt>null</tt> will be returned.
+     * If no answer is received from the server before the specified timeout then <code>null</code> will be returned.
      *
      * Components are trusted by the server and may use any value in from address. Usually
      * the from address uses the component's address as the domain but this is not required.
@@ -76,7 +76,7 @@ public interface ComponentManager {
      * @param packet the IQ packet to send.
      * @param timeout the number of milliseconds to wait before returning an IQ error.
      * @return the answer sent by the server. The answer could be an IQ of type result or
-     *         error. <tt>null</tt> will be returned if there is no response from the server.
+     *         error. <code>null</code> will be returned if there is no response from the server.
      * @throws ComponentException if the component connection is lost or unavialble during the time of sending and
      * recieving packets.
      */

--- a/src/main/java/org/xmpp/component/ComponentManagerFactory.java
+++ b/src/main/java/org/xmpp/component/ComponentManagerFactory.java
@@ -22,7 +22,7 @@ package org.xmpp.component;
  *
  *      <li>An external process can set the ComponentManager using
  *      {@link #setComponentManager(ComponentManager)}.
- *      <li>If the component manager is <tt>null</tt>, the factory will check for
+ *      <li>If the component manager is <code>null</code>, the factory will check for
  *      the Java system property "whack.componentManagerClass". The value of the
  *      property should be the fully qualified class name of a ComponentManager
  *      implementation (e.g. com.foo.MyComponentManager). The class must have a default

--- a/src/main/java/org/xmpp/forms/DataForm.java
+++ b/src/main/java/org/xmpp/forms/DataForm.java
@@ -187,7 +187,7 @@ public class DataForm extends PacketExtension {
      * and what the form is about. The dataform could include multiple instructions since each
      * instruction could not contain newlines characters.
      * <p>
-     * Nothing will be set, if the provided argument is <tt>null</tt> or an empty String.
+     * Nothing will be set, if the provided argument is <code>null</code> or an empty String.
      *
      * @param instruction the new instruction that explain how to fill out the form.
      */
@@ -221,7 +221,7 @@ public class DataForm extends PacketExtension {
 
     /**
      * Adds a new field as part of the form. The provided arguments are optional
-     * (they are allowed to be <tt>null</tt>).
+     * (they are allowed to be <code>null</code>).
      *
      * @param variable the unique identifier of the field in the context of the
      * 		form. Optional parameter.
@@ -322,9 +322,9 @@ public class DataForm extends PacketExtension {
     }
 
     /**
-     * Adds a new row of items of reported data. For each entry in the <tt>fields</tt> parameter
-     * a <tt>field</tt> element will be added to the &lt;item&gt; element. The variable of the new
-     * <tt>field</tt> will be the key of the entry. The new <tt>field</tt> will have several values
+     * Adds a new row of items of reported data. For each entry in the <code>fields</code> parameter
+     * a <code>field</code> element will be added to the &lt;item&gt; element. The variable of the new
+     * <code>field</code> will be the key of the entry. The new <code>field</code> will have several values
      * if the entry's value is a {@link Collection}. Since the value is of type {@link Object} it
      * is possible to include any type of object as a value. The actual value to include in the
      * data form is the result of the {@link #encode(Object)} method.

--- a/src/main/java/org/xmpp/forms/FormField.java
+++ b/src/main/java/org/xmpp/forms/FormField.java
@@ -44,7 +44,7 @@ public class FormField {
      * Adds a default value to the question if the question is part of a form to fill out.
      * Otherwise, adds an answered value to the question.
      * <p>
-     * Nothing will be added if the provided argument is <tt>null</tt>.
+     * Nothing will be added if the provided argument is <code>null</code>.
      *
      * @param value a default value or an answered value of the question.
      */
@@ -70,7 +70,7 @@ public class FormField {
      * Adds an available option to the question that the user has in order to answer
      * the question.
      * <p>
-     * If argument 'value' is <tt>null</tt> or an empty String, no option element
+     * If argument 'value' is <code>null</code> or an empty String, no option element
      * will be added.
      *
      * @param label a label that represents the option. Optional argument.
@@ -168,7 +168,7 @@ public class FormField {
      * If the question is of type FIXED then the description should remain empty.
      * </p>
      * <p>
-     * No new description will be set, if the provided argument is <tt>null</tt> or an empty
+     * No new description will be set, if the provided argument is <code>null</code> or an empty
      * String (although an existing description will be removed).
      * </p>
      *
@@ -334,7 +334,7 @@ public class FormField {
      * Implementation note: XMPP error conditions use "-" characters in
      * their names such as "jid-multi". Because "-" characters are not valid
      * identifier parts in Java, they have been converted to "_" characters in
-     * the  enumeration names, such as <tt>jid_multi</tt>. The {@link #toXMPP()} and
+     * the  enumeration names, such as <code>jid_multi</code>. The {@link #toXMPP()} and
      * {@link #fromXMPP(String)} methods can be used to convert between the
      * enumertation values and Type code strings.
      */

--- a/src/main/java/org/xmpp/muc/DestroyRoom.java
+++ b/src/main/java/org/xmpp/muc/DestroyRoom.java
@@ -37,8 +37,8 @@ public class DestroyRoom extends IQ {
     /**
      * Creates a new DestroyRoom with the reason for the destruction and an alternate room JID.
      *
-     * @param alternateJID JID of the alternate room or <tt>null</tt> if none.
-     * @param reason       reason for the destruction or <tt>null</tt> if none.
+     * @param alternateJID JID of the alternate room or <code>null</code> if none.
+     * @param reason       reason for the destruction or <code>null</code> if none.
      */
     public DestroyRoom(JID alternateJID, String reason) {
         super();

--- a/src/main/java/org/xmpp/packet/IQ.java
+++ b/src/main/java/org/xmpp/packet/IQ.java
@@ -281,8 +281,8 @@ public class IQ extends Packet {
 
     /**
      * Returns a {@link PacketExtension} on the first element found in this packet's
-     * child element for the specified <tt>name</tt> and <tt>namespace</tt> or <tt>null</tt> if
-     * none was found. If the IQ packet does not have a child element then <tt>null</tt>
+     * child element for the specified <code>name</code> and <code>namespace</code> or <code>null</code> if
+     * none was found. If the IQ packet does not have a child element then <code>null</code>
      * will be returned.<p>
      *
      * Note: packet extensions on IQ packets are only for use in specialized situations.
@@ -291,7 +291,7 @@ public class IQ extends Packet {
      * @param name the child element name.
      * @param namespace the child element namespace.
      * @return a PacketExtension on the first element found in this packet for the specified
-     *         name and namespace or <tt>null</tt> if none was found.
+     *         name and namespace or <code>null</code> if none was found.
      */
     @SuppressWarnings("unchecked")
     public PacketExtension getExtension(String name, String namespace) {
@@ -319,7 +319,7 @@ public class IQ extends Packet {
      * Deletes the first element whose element name and namespace matches the specified
      * element name and namespace in this packet's child element. If the
      * IQ packet does not have a child element then this method does nothing and returns
-     * <tt>false</tt>.<p>
+     * <code>false</code>.<p>
      *
      * Notice that this method may remove any child element that matches the specified
      * element name and namespace even if that element was not added to the Packet using a

--- a/src/main/java/org/xmpp/packet/JID.java
+++ b/src/main/java/org/xmpp/packet/JID.java
@@ -39,9 +39,9 @@ import java.time.Duration;
  *
  * Some sample JID's:
  * <ul>
- * <li><tt>user@example.com</tt></li>
- * <li><tt>user@example.com/home</tt></li>
- * <li><tt>example.com</tt></li>
+ * <li><code>user@example.com</code></li>
+ * <li><code>user@example.com/home</code></li>
+ * <li><code>example.com</code></li>
  * </ul>
  *
  * Each allowable portion of a JID (node, domain, and resource) must not be more
@@ -290,7 +290,7 @@ public class JID implements Comparable<JID>, Serializable {
      *            The raw node value.
      * @return A String based JID node representation
      * @throws IllegalArgumentException
-     *             if <tt>node</tt> is not a valid JID node.
+     *             if <code>node</code> is not a valid JID node.
      */
     public static String nodeprep(String node) {
         if (node == null) {
@@ -346,7 +346,7 @@ public class JID implements Comparable<JID>, Serializable {
      *            The raw domain value.
      * @return A String based JID domain part representation
      * @throws IllegalArgumentException
-     *             if <tt>domain</tt> is not a valid JID domain part.
+     *             if <code>domain</code> is not a valid JID domain part.
      */
     public static String domainprep(String domain) {
         if (domain == null) {
@@ -402,7 +402,7 @@ public class JID implements Comparable<JID>, Serializable {
      *            The raw resource value.
      * @return A String based JID resource representation
      * @throws IllegalArgumentException
-     *             if <tt>resource</tt> is not a valid JID resource.
+     *             if <code>resource</code> is not a valid JID resource.
      */
     public static String resourceprep(String resource) {
         if (resource == null) {
@@ -465,7 +465,7 @@ public class JID implements Comparable<JID>, Serializable {
      * @param jid
      *            a valid JID.
      * @param skipStringPrep
-     *            <tt>true</tt> if stringprep should not be applied.
+     *            <code>true</code> if stringprep should not be applied.
      * @throws IllegalArgumentException
      *             if the JID is not valid.
      */
@@ -481,9 +481,9 @@ public class JID implements Comparable<JID>, Serializable {
      * Constructs a JID given a node, domain, and resource.
      *
      * @param node the node.
-     * @param domain the domain, which must not be <tt>null</tt>.
+     * @param domain the domain, which must not be <code>null</code>.
      * @param resource the resource.
-     * @throws NullPointerException if domain is <tt>null</tt>.
+     * @throws NullPointerException if domain is <code>null</code>.
      * @throws IllegalArgumentException if the JID is not valid.
      */
     public JID(String node, String domain, String resource) {
@@ -495,10 +495,10 @@ public class JID implements Comparable<JID>, Serializable {
      * should be applied or not.
      *
      * @param node the node.
-     * @param domain the domain, which must not be <tt>null</tt>.
+     * @param domain the domain, which must not be <code>null</code>.
      * @param resource the resource.
-     * @param skipStringprep <tt>true</tt> if stringprep should not be applied.
-     * @throws NullPointerException if domain is <tt>null</tt>.
+     * @param skipStringprep <code>true</code> if stringprep should not be applied.
+     * @throws NullPointerException if domain is <code>null</code>.
      * @throws IllegalArgumentException if the JID is not valid.
      */
     public JID(String node, String domain, String resource, boolean skipStringprep) {
@@ -606,7 +606,7 @@ public class JID implements Comparable<JID>, Serializable {
     }
 
     /**
-     * Returns the node, or <tt>null</tt> if this JID does not contain node information.
+     * Returns the node, or <code>null</code> if this JID does not contain node information.
      *
      * @return the node.
      */
@@ -624,7 +624,7 @@ public class JID implements Comparable<JID>, Serializable {
     }
 
     /**
-     * Returns the resource, or <tt>null</tt> if this JID does not contain resource information.
+     * Returns the resource, or <code>null</code> if this JID does not contain resource information.
      *
      * @return the resource.
      */
@@ -634,7 +634,7 @@ public class JID implements Comparable<JID>, Serializable {
 
     /**
      * Returns the String representation of the bare JID, which is the JID with
-     * resource information removed. For example: <tt>username@domain.com</tt>
+     * resource information removed. For example: <code>username@domain.com</code>
      *
      * @return the bare JID.
      */
@@ -650,7 +650,7 @@ public class JID implements Comparable<JID>, Serializable {
 
     /**
      * Returns the bare JID representation of this JID, which is the JID with
-     * resource information removed. For example: <tt>username@domain.com</tt>
+     * resource information removed. For example: <code>username@domain.com</code>
      *
      * @return the bare JID.
      * @see <a href="http://issues.igniterealtime.org/browse/TINDER-68">TINDER-68</a>
@@ -661,7 +661,7 @@ public class JID implements Comparable<JID>, Serializable {
 
     /**
      * Returns the String representation of the full JID, for example:
-     * <tt>username@domain.com/mobile</tt>.
+     * <code>username@domain.com/mobile</code>.
      *
      * If no resource has been provided in the constructor of this object, an
      * IllegalStateException is thrown.
@@ -768,7 +768,7 @@ public class JID implements Comparable<JID>, Serializable {
      *      <li>Resources are normalized using resourceprep (case sensitive).</ul>
      *
      * These normalization rules ensure, for example, that
-     * <tt>User@EXAMPLE.com/home</tt> is considered equal to <tt>user@example.com/home</tt>.
+     * <code>User@EXAMPLE.com/home</code> is considered equal to <code>user@example.com/home</code>.
      *
      * @param jid1 a JID.
      * @param jid2 a JID.

--- a/src/main/java/org/xmpp/packet/Message.java
+++ b/src/main/java/org/xmpp/packet/Message.java
@@ -111,7 +111,7 @@ public class Message extends Packet {
     }
 
     /**
-     * Returns the subject of this message or <tt>null</tt> if there is no subject..
+     * Returns the subject of this message or <code>null</code> if there is no subject..
      *
      * @return the subject.
      */
@@ -142,7 +142,7 @@ public class Message extends Packet {
     }
 
     /**
-     * Returns the body of this message or <tt>null</tt> if there is no body.
+     * Returns the body of this message or <code>null</code> if there is no body.
      *
      * @return the body.
      */
@@ -173,7 +173,7 @@ public class Message extends Packet {
     /**
      * Returns the thread value of this message, an identifier that is used for
      * tracking a conversation thread ("instant messaging session")
-     * between two entities. If the thread is not set, <tt>null</tt> will be
+     * between two entities. If the thread is not set, <code>null</code> will be
      * returned.
      *
      * @return the thread value.
@@ -208,7 +208,7 @@ public class Message extends Packet {
     /**
      * Returns the first child element of this packet that matches the
      * given name and namespace. If no matching element is found,
-     * <tt>null</tt> will be returned. This is a convenience method to avoid
+     * <code>null</code> will be returned. This is a convenience method to avoid
      * manipulating this underlying packet's Element instance directly.<p>
      *
      * Child elements in extended namespaces are used to extend the features
@@ -220,7 +220,7 @@ public class Message extends Packet {
      *
      * @param name the element name.
      * @param namespace the element namespace.
-     * @return the first matching child element, or <tt>null</tt> if there
+     * @return the first matching child element, or <code>null</code> if there
      *      is no matching child element.
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/xmpp/packet/Packet.java
+++ b/src/main/java/org/xmpp/packet/Packet.java
@@ -74,7 +74,7 @@ public abstract class Packet {
      * Constructs a new Packet. The JID address contained in the XML Element may not be
      * validated. When validation can be skipped then stringprep operations will not be performed
      * on the JIDs to verify that addresses are well-formed. However, when validation cannot be
-     * skipped then <tt>only</tt> the TO address will be verified. The FROM address is assigned by
+     * skipped then <code>only</code> the TO address will be verified. The FROM address is assigned by
      * the server so there is no need to verify it.
      *
      * @param element the XML Element that contains the packet contents.
@@ -117,7 +117,7 @@ public abstract class Packet {
     }
 
     /**
-     * Returns the packet ID, or <tt>null</tt> if the packet does not have an ID.
+     * Returns the packet ID, or <code>null</code> if the packet does not have an ID.
      * Packet ID's are optional, except for IQ packets.
      *
      * @return the packet ID.
@@ -136,11 +136,11 @@ public abstract class Packet {
     }
 
     /**
-     * Returns the XMPP address (JID) that the packet is addressed to, or <tt>null</tt>
+     * Returns the XMPP address (JID) that the packet is addressed to, or <code>null</code>
      * if the "to" attribute is not set. The XMPP protocol often makes the "to"
      * attribute optional, so it does not always need to be set.
      *
-     * @return the XMPP address (JID) that the packet is addressed to, or <tt>null</tt>
+     * @return the XMPP address (JID) that the packet is addressed to, or <code>null</code>
      *      if not set.
      */
     public JID getTo() {
@@ -195,11 +195,11 @@ public abstract class Packet {
     }
 
     /**
-     * Returns the XMPP address (JID) that the packet is from, or <tt>null</tt>
+     * Returns the XMPP address (JID) that the packet is from, or <code>null</code>
      * if the "from" attribute is not set. The XMPP protocol often makes the "from"
      * attribute optional, so it does not always need to be set.
      *
-     * @return the XMPP address that the packet is from, or <tt>null</tt>
+     * @return the XMPP address that the packet is from, or <code>null</code>
      *      if not set.
      */
     public JID getFrom() {
@@ -268,7 +268,7 @@ public abstract class Packet {
 
     /**
      * Returns a {@link PacketExtension} on the first element found in this packet
-     * for the specified <tt>name</tt> and <tt>namespace</tt> or <tt>null</tt> if
+     * for the specified <code>name</code> and <code>namespace</code> or <code>null</code> if
      * none was found.
      *
      * @param name the child element name.
@@ -322,7 +322,7 @@ public abstract class Packet {
     }
 
     /**
-     * Returns the packet error, or <tt>null</tt> if there is no packet error.
+     * Returns the packet error, or <code>null</code> if there is no packet error.
      *
      * @return the packet error.
      */
@@ -359,7 +359,7 @@ public abstract class Packet {
      * method will automatically set the packet "type" attribute to "error".
      * This is a convenience method equivalent to calling:
      *
-     * <tt>setError(new PacketError(condition));</tt>
+     * <code>setError(new PacketError(condition));</code>
      *
      * @param condition the error condition.
      */

--- a/src/main/java/org/xmpp/packet/PacketError.java
+++ b/src/main/java/org/xmpp/packet/PacketError.java
@@ -191,7 +191,7 @@ public class PacketError {
     }
 
     /**
-     * Returns a text description of the error, or <tt>null</tt> if there
+     * Returns a text description of the error, or <code>null</code> if there
      * is no text description.
      *
      * @return the text description of the error.
@@ -214,7 +214,7 @@ public class PacketError {
      * can be specified to indicate the language of the description.
      *
      * @param text the text description of the error.
-     * @param lang the language code of the description, or <tt>null</tt> to specify
+     * @param lang the language code of the description, or <code>null</code> to specify
      *      no language code.
      */
     public void setText(String text, String lang) {
@@ -239,7 +239,7 @@ public class PacketError {
     }
 
     /**
-     * Returns the text description's language code, or <tt>null</tt> if there
+     * Returns the text description's language code, or <code>null</code> if there
      * is no language code associated with the description text.
      *
      * @return the language code of the text description, if it exists.
@@ -304,7 +304,7 @@ public class PacketError {
 
     /**
      * Returns the name of the application-specific error condition,
-     * or <tt>null</tt> if there is no application-specific error.
+     * or <code>null</code> if there is no application-specific error.
      *
      * @return the name of the application-specific error condition, if it exists.
      */
@@ -321,7 +321,7 @@ public class PacketError {
 
     /**
      * Returns the namespace of the application-specific error condition,
-     * or <tt>null</tt> if there is no application-specific error.
+     * or <code>null</code> if there is no application-specific error.
      *
      * @return the namespace of the application-specific error condition, if it exists.
      */
@@ -373,7 +373,7 @@ public class PacketError {
      * Implementation note: XMPP error conditions use "-" characters in
      * their names such as "bad-request". Because "-" characters are not valid
      * identifier parts in Java, they have been converted to "_" characters in
-     * the  enumeration names, such as <tt>bad_request</tt>. The {@link #toXMPP()} and
+     * the  enumeration names, such as <code>bad_request</code>. The {@link #toXMPP()} and
      * {@link #fromXMPP(String)} methods can be used to convert between the
      * enumertation values and XMPP error code strings.
      */
@@ -708,7 +708,7 @@ public class PacketError {
      * </ul>
      *
      * Implementation note: one of the XMPP error types is "continue". Because "continue"
-     * is a reserved Java keyword, the enum name is <tt>continue_processing</tt>. The
+     * is a reserved Java keyword, the enum name is <code>continue_processing</code>. The
      * {@link #toXMPP()} and {@link #fromXMPP(String)} methods can be used to convert
      * between the enumertation values and XMPP error type strings.
      */

--- a/src/main/java/org/xmpp/packet/PacketExtension.java
+++ b/src/main/java/org/xmpp/packet/PacketExtension.java
@@ -31,7 +31,7 @@ import org.dom4j.QName;
  * element. The wrapper provides an easy way to handle the packet extension.<p>
  *
  * Subclasses of this class can be registered using the static variable
- * <tt>registeredExtensions</tt>. The registration process associates the new subclass
+ * <code>registeredExtensions</code>. The registration process associates the new subclass
  * with a given qualified name (ie. element name and namespace). This information will be used by
  * {@link Packet#getExtension(String, String)} for locating the corresponding PacketExtension
  * subclass to return for the requested qualified name. Each PacketExtension must have a public

--- a/src/main/java/org/xmpp/packet/Presence.java
+++ b/src/main/java/org/xmpp/packet/Presence.java
@@ -103,10 +103,10 @@ public class Presence extends Packet {
 
     /**
      * Returns the type of this presence. If the presence is "available", the
-     * type will be <tt>null</tt> (in XMPP, no value for the type attribute is
+     * type will be <code>null</code> (in XMPP, no value for the type attribute is
      * defined as available).
      *
-     * @return the presence type or <tt>null</tt> if "available".
+     * @return the presence type or <code>null</code> if "available".
      * @see Type
      */
     public Type getType() {
@@ -131,8 +131,8 @@ public class Presence extends Packet {
     /**
      * Returns the presence "show" value, which specifies a particular availability
      * status. If the &lt;show&gt; element is not present, this method will return
-     * <tt>null</tt>. The show value can only be set if the presence type is "avaialble".
-     * A <tt>null</tt> show value is used to represent "available", which is the
+     * <code>null</code>. The show value can only be set if the presence type is "avaialble".
+     * A <code>null</code> show value is used to represent "available", which is the
      * default.
      *
      * @return the presence show value..
@@ -150,7 +150,7 @@ public class Presence extends Packet {
     /**
      * Sets the presence "show" value, which specifies a particular availability
      * status. The show value can only be set if the presence type is "available".
-     * A <tt>null</tt> show value is used to represent "available", which is the
+     * A <code>null</code> show value is used to represent "available", which is the
      * default.
      *
      * @param show the presence show value.
@@ -249,7 +249,7 @@ public class Presence extends Packet {
     /**
      * Returns the first child element of this packet that matches the
      * given name and namespace. If no matching element is found,
-     * <tt>null</tt> will be returned. This is a convenience method to avoid
+     * <code>null</code> will be returned. This is a convenience method to avoid
      * manipulating this underlying packet's Element instance directly.<p>
      *
      * Child elements in extended namespaces are used to extend the features
@@ -261,7 +261,7 @@ public class Presence extends Packet {
      *
      * @param name the element name.
      * @param namespace the element namespace.
-     * @return the first matching child element, or <tt>null</tt> if there
+     * @return the first matching child element, or <code>null</code> if there
      *      is no matching child element.
      */
     @SuppressWarnings("unchecked")
@@ -307,7 +307,7 @@ public class Presence extends Packet {
 
     /**
      * Represents the type of a presence packet. Note: the presence is assumed
-     * to be "available" when the type attribute of the packet is <tt>null</tt>.
+     * to be "available" when the type attribute of the packet is <code>null</code>.
      * The valid types are:
      *
      *  <ul>
@@ -369,7 +369,7 @@ public class Presence extends Packet {
     }
 
     /**
-     * Represents the presence "show" value. Note: a <tt>null</tt> "show" value is the
+     * Represents the presence "show" value. Note: a <code>null</code> "show" value is the
      * default, which means "available". Valid values are:
      *
      * <ul>

--- a/src/main/java/org/xmpp/packet/Roster.java
+++ b/src/main/java/org/xmpp/packet/Roster.java
@@ -93,7 +93,7 @@ public class Roster extends IQ {
     }
 
     /**
-     * Adds a new item to the roster. The name and groups are set to <tt>null</tt>
+     * Adds a new item to the roster. The name and groups are set to <code>null</code>
      * If the roster packet already contains an item using the same JID, the
      * information in the existing item will be overwritten with the new information.<p>
      *
@@ -116,7 +116,7 @@ public class Roster extends IQ {
     }
 
     /**
-     * Adds a new item to the roster. The name and groups are set to <tt>null</tt>
+     * Adds a new item to the roster. The name and groups are set to <code>null</code>
      * If the roster packet already contains an item using the same JID, the
      * information in the existing item will be overwritten with the new information.<p>
      *
@@ -298,9 +298,9 @@ public class Roster extends IQ {
 
         /**
          * Returns the nickname associated with this item. If no nickname exists,
-         * <tt>null</tt> is returned.
+         * <code>null</code> is returned.
          *
-         * @return the nickname, or <tt>null</tt> if it doesn't exist.
+         * @return the nickname, or <code>null</code> if it doesn't exist.
          */
         public String getName() {
             return name;

--- a/src/main/java/org/xmpp/packet/StreamError.java
+++ b/src/main/java/org/xmpp/packet/StreamError.java
@@ -136,7 +136,7 @@ public class StreamError {
     }
 
     /**
-     * Returns a text description of the error, or <tt>null</tt> if there
+     * Returns a text description of the error, or <code>null</code> if there
      * is no text description.
      *
      * @return the text description of the error.
@@ -159,7 +159,7 @@ public class StreamError {
      * can be specified to indicate the language of the description.
      *
      * @param text the text description of the error.
-     * @param language the language code of the description, or <tt>null</tt> to specify
+     * @param language the language code of the description, or <code>null</code> to specify
      *      no language code.
      */
     public void setText(String text, String language) {
@@ -184,7 +184,7 @@ public class StreamError {
     }
 
     /**
-     * Returns the text description's language code, or <tt>null</tt> if there
+     * Returns the text description's language code, or <code>null</code> if there
      * is no language code associated with the description text.
      *
      * @return the language code of the text description, if it exists.
@@ -236,7 +236,7 @@ public class StreamError {
      * Implementation note: XMPP error conditions use "-" characters in
      * their names such as "bad-request". Because "-" characters are not valid
      * identifier parts in Java, they have been converted to "_" characters in
-     * the  enumeration names, such as <tt>bad_request</tt>. The {@link #toXMPP()} and
+     * the  enumeration names, such as <code>bad_request</code>. The {@link #toXMPP()} and
      * {@link #fromXMPP(String)} methods can be used to convert between the
      * enumertation values and XMPP error code strings.
      */

--- a/src/main/java/org/xmpp/util/ValueWrapper.java
+++ b/src/main/java/org/xmpp/util/ValueWrapper.java
@@ -102,7 +102,7 @@ public class ValueWrapper<V> implements Serializable {
     }
 
     /**
-     * Wraps a value while using the <tt>USE_VALUE</tt> representation.
+     * Wraps a value while using the <code>USE_VALUE</code> representation.
      *
      * @param value
      *            The value that is wrapped.
@@ -114,7 +114,7 @@ public class ValueWrapper<V> implements Serializable {
     }
 
     /**
-     * Returns the wrapped value, or <tt>null</tt> if the representation used in
+     * Returns the wrapped value, or <code>null</code> if the representation used in
      * this instance is not USE_VALUE;
      *
      * @return the wrapped value.

--- a/src/test/java/org/xmpp/component/AbstractComponentServiceDiscovery.java
+++ b/src/test/java/org/xmpp/component/AbstractComponentServiceDiscovery.java
@@ -47,7 +47,7 @@ public class AbstractComponentServiceDiscovery {
 	private IQ response = null;
 
 	/**
-	 * Makes sure that the <tt>response</tt> field of this class is assigned a
+	 * Makes sure that the <code>response</code> field of this class is assigned a
 	 * fresh response to a service discovery information request.
 	 * 
 	 */

--- a/src/test/java/org/xmpp/component/SlowRespondingThreadNameComponent.java
+++ b/src/test/java/org/xmpp/component/SlowRespondingThreadNameComponent.java
@@ -24,8 +24,8 @@ import org.xmpp.packet.IQ;
  * functionality, intended to be used by unit tests.
  * 
  * This component will respond to IQ-get requests containing a child element
- * escaped by the namespace <tt>tinder:debug</tt>. If the child element name is
- * <tt>threadname</tt>, a response will be generated that reports the name of
+ * escaped by the namespace <code>tinder:debug</code>. If the child element name is
+ * <code>threadname</code>, a response will be generated that reports the name of
  * the thread used to process the stanza, as shown:
  * 
  * <pre>
@@ -40,7 +40,7 @@ import org.xmpp.packet.IQ;
  * &lt;/iq&gt;
  * </pre>
  * 
- * If the element name is <tt>slowresponse</tt>, an empty response will be
+ * If the element name is <code>slowresponse</code>, an empty response will be
  * generated 4000 milliseconds after the request was delivered to the component.
  * 
  * <pre>

--- a/src/test/java/org/xmpp/packet/JIDDelimiterCharsTest.java
+++ b/src/test/java/org/xmpp/packet/JIDDelimiterCharsTest.java
@@ -8,8 +8,8 @@ import org.junit.Test;
 /**
  * When composing JIDs, two delimiter characters can be used:
  * <ul>
- * <li><tt>@</tt> (at)</li>
- * <li><tt>/</tt> (forward slash)</li>
+ * <li><code>@</code> (at)</li>
+ * <li><code>/</code> (forward slash)</li>
  * </ul>
  * 
  * Tests in this class verify that usage of those characters as part of the JID is processed correctly.

--- a/src/test/java/org/xmpp/packet/PacketAddressingTest.java
+++ b/src/test/java/org/xmpp/packet/PacketAddressingTest.java
@@ -53,7 +53,7 @@ public class PacketAddressingTest {
 	}
 
 	/**
-	 * To and From addresses should be allowed to be <tt>null</tt>.
+	 * To and From addresses should be allowed to be <code>null</code>.
 	 */
 	@Test
 	public void testAllowNullToJID() throws Exception {
@@ -63,7 +63,7 @@ public class PacketAddressingTest {
 	}
 
 	/**
-	 * To and From addresses should be allowed to be <tt>null</tt>.
+	 * To and From addresses should be allowed to be <code>null</code>.
 	 */
 	@Test
 	public void testAllowNullToString() throws Exception {
@@ -157,7 +157,7 @@ public class PacketAddressingTest {
 	}
 
 	/**
-	 * To and From addresses should be allowed to be <tt>null</tt>.
+	 * To and From addresses should be allowed to be <code>null</code>.
 	 */
 	@Test
 	public void testAllowNullFromJID() throws Exception {
@@ -167,7 +167,7 @@ public class PacketAddressingTest {
 	}
 
 	/**
-	 * To and From addresses should be allowed to be <tt>null</tt>.
+	 * To and From addresses should be allowed to be <code>null</code>.
 	 */
 	@Test
 	public void testAllowNullFromString() throws Exception {


### PR DESCRIPTION
To make the default compiler happier.