### PR TITLE
TINDER-81: Fix typo in Roster

### DIFF
--- a/src/main/java/org/xmpp/packet/Roster.java
+++ b/src/main/java/org/xmpp/packet/Roster.java
@@ -344,7 +344,7 @@ public class Roster extends IQ {
             if (name != null) {
                 buf.append(" name=\"").append(name).append("\"");
             }
-            buf.append(" subscrption=\"").append(subscription).append("\"");
+            buf.append(" subscription=\"").append(subscription).append("\"");
             if (groups == null || groups.isEmpty()) {
                 buf.append("/>");
             } else {


### PR DESCRIPTION
The ‘toString’ of the Roster class will include the word subscrption which arguably should be subscription.

toString wouldn’t typically be used for anything other than make humans understand the composition of the instance. In cases where this is not the case, users would benefit from having a correction (although existing users will see a breakage because of this change).